### PR TITLE
Enable Hackage-friendly Stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -22,3 +22,4 @@ extra-include-dirs:
 - /usr/local/opt/icu4c/include
 
 resolver: lts-7.11
+pvp-bounds: both


### PR DESCRIPTION
This will help keeping `rasa`'s install-plan from bitrotting over time and therefore avoid our Haddock doc builder failing to rebuild docs, as well as users running into compile errors, and last but not least reduce the overhead for us [Hackage Trustees](https://hackage.haskell.org/packages/trustees/) having to step in and fixup `.cabal` files :-)

See also https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds