### PR TITLE
Add async-actions

### DIFF
--- a/docs/Building-An-Extension.md
+++ b/docs/Building-An-Extension.md
@@ -32,7 +32,7 @@ It should look something like this:
 import Rasa
 -- ... some other imports
 main :: IO ()
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   vim
   files
   cursors
@@ -57,7 +57,7 @@ helloWorld :: Action ()
 helloWorld = writeFile "hello-world.txt" "Hello, World!"
 
 main :: IO ()
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   -- some plugins...
   -- Add the new action here!
   helloWorld
@@ -132,7 +132,7 @@ Under the hood it just calls `eventListener` for the `Init` event which is dispa
 a nifty helper to make things simpler. Let's use it to schedule our `helloWorld` Action.
 
 ```haskell
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   -- other extensions
   onInit helloWorld
 ```
@@ -188,7 +188,7 @@ got our function from our event type (Keypress), so let's try embedding it
 using `eventListener`
 
 ```haskell
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   -- other extensions
   eventListener helloWorld
 ```
@@ -234,7 +234,7 @@ going to power through it!
 import Rasa.Ext.Cursors
 import Rasa.Control.Lens
 
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   -- other extensions
   cursors
   eventListener copyPasta
@@ -523,7 +523,7 @@ Okay fine! Let's listen for the events so we can see them coming through!
 copyListener :: Copied -> Action ()
 copyListener (Copied str) = liftIO $ appendFile "copied.txt" ("Copied: " ++ str ++ "\n")
 
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   -- other extensions
   eventListener copyListener
 ```

--- a/docs/CopyPasta.hs
+++ b/docs/CopyPasta.hs
@@ -47,7 +47,7 @@ copyListener :: Copied -> Action ()
 copyListener (Copied str) = liftIO $ appendFile "copied.txt" ("Copied: " ++ str ++ "\n")
 
 main :: IO ()
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   vim
   statusBar
   files

--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -9,10 +9,11 @@ import Rasa.Ext.Logger
 import Rasa.Ext.Cursors
 import Rasa.Renderer.Slate
 
--- | This is the main of an executable that runs rasa with the given extensions registered to receive event hooks
--- 
--- 'terminalEvents' is an event provider which listens for key-presses etc.
+-- | This is the main of an executable that runs rasa with any extensions the
+-- user wants
+--
 -- The @do@ block is of type 'Rasa.Ext.Scheduler.Scheduler'
+
 main :: IO ()
 main = rasa $ do
   vim

--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -14,7 +14,7 @@ import Rasa.Renderer.Slate
 -- 'terminalEvents' is an event provider which listens for key-presses etc.
 -- The @do@ block is of type 'Rasa.Ext.Scheduler.Scheduler'
 main :: IO ()
-main = rasa [terminalEvents] $ do
+main = rasa $ do
   vim
   statusBar
   files

--- a/rasa-ext-logger/src/Rasa/Ext/Logger.hs
+++ b/rasa-ext-logger/src/Rasa/Ext/Logger.hs
@@ -7,13 +7,14 @@ module Rasa.Ext.Logger
 import Rasa.Ext
 
 import Control.Monad.State
+import Control.Lens
 
 logger :: Scheduler ()
 logger = do
   onInit $ liftIO $ writeFile "logs.log" "Event Log\n"
   afterRender $ do
-    editor <- get
-    liftIO $ appendFile "logs.log" (show editor)
+    ed <- use editor
+    liftIO $ appendFile "logs.log" (show ed)
 
 logInfo :: String -> Action ()
 logInfo msg = liftIO $ appendFile "info.log" ("INFO: " ++ msg ++ "\n")

--- a/rasa-ext-slate/src/Rasa/Renderer/Slate.hs
+++ b/rasa-ext-slate/src/Rasa/Renderer/Slate.hs
@@ -12,7 +12,7 @@ import Control.Monad.IO.Class
 --
 -- e.g.
 --
--- > rasa [...] $ do
+-- > rasa $ do
 -- >    slate
 -- >    ...
 slate :: Scheduler ()

--- a/rasa-ext-slate/src/Rasa/Renderer/Slate.hs
+++ b/rasa-ext-slate/src/Rasa/Renderer/Slate.hs
@@ -1,4 +1,4 @@
-module Rasa.Renderer.Slate (slate, terminalEvents) where
+module Rasa.Renderer.Slate (slate) where
 
 import Rasa.Ext
 import Rasa.Renderer.Slate.Render (render)
@@ -17,6 +17,7 @@ import Control.Monad.IO.Class
 -- >    ...
 slate :: Scheduler ()
 slate = do
+  onInit terminalEvents
   onRender render
   onExit shutdown
 

--- a/rasa-ext-slate/src/Rasa/Renderer/Slate/Event.hs
+++ b/rasa-ext-slate/src/Rasa/Renderer/Slate/Event.hs
@@ -3,29 +3,27 @@ module Rasa.Renderer.Slate.Event (terminalEvents) where
 import Rasa.Ext
 
 import Rasa.Renderer.Slate.State
-import Control.Monad.IO.Class
-import Data.Maybe
 
 import qualified Graphics.Vty as V
 
 -- | Provides keypress events from the terminal, converted from Vty events.
-terminalEvents :: Action [Keypress]
+terminalEvents :: Action ()
 terminalEvents = do
     v <- getVty
-    liftIO $ maybeToList . convertEvent <$> V.nextEvent v
+    eventProvider $ convertEvent <$> V.nextEvent v
 
 -- | Converts a 'V.Event' into a keypress if possible.
-convertEvent :: V.Event -> Maybe Keypress
+convertEvent :: V.Event -> Keypress
 convertEvent (V.EvKey e mods) = convertKeypress e mods
-convertEvent _ = Nothing
+convertEvent _ = Unknown
 
 -- | Converts a 'V.Event' into a keypress if possible.
-convertKeypress :: V.Key -> [V.Modifier] -> Maybe Keypress
-convertKeypress V.KEnter _ = Just Enter
-convertKeypress V.KBS _ = Just BS
-convertKeypress V.KEsc _ = Just Esc
-convertKeypress (V.KChar c) mods  = Just $ Keypress c (fmap convertMod mods)
-convertKeypress _ _  = Nothing
+convertKeypress :: V.Key -> [V.Modifier] -> Keypress
+convertKeypress V.KEnter _ = Enter
+convertKeypress V.KBS _ = BS
+convertKeypress V.KEsc _ = Esc
+convertKeypress (V.KChar c) mods  = Keypress c (fmap convertMod mods)
+convertKeypress _ _ = Unknown
 
 -- | Converts a 'V.Modifier' into a 'Mod'.
 convertMod :: V.Modifier -> Mod

--- a/rasa-ext-style/src/Rasa/Ext/Style.hs
+++ b/rasa-ext-style/src/Rasa/Ext/Style.hs
@@ -83,7 +83,7 @@ addStyle r st = styles %= (Span r st:)
 --
 -- e.g.
 --
--- > rasa [...] $ do
+-- > rasa $ do
 -- >    style
 -- >    ...
 style :: Scheduler ()

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -8,6 +8,7 @@ import Rasa.Ext.Files (save)
 import Rasa.Ext.Cursors
 import Rasa.Ext.StatusBar
 
+import Control.Monad.IO.Class
 import Control.Lens
 import Data.Text.Lens (packed)
 import Data.Default

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -37,7 +37,7 @@ setMode vimst = bufExt .= vimst
 --
 -- e.g.
 --
--- > rasa [keypressProvider] $ do
+-- > rasa $ do
 -- >    vim
 -- >    ...
 vim :: Scheduler ()

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -56,6 +56,7 @@ library
                        Rasa.Ext
 
                        Rasa.Internal.Action
+                       Rasa.Internal.Async
                        Rasa.Internal.Buffer
                        Rasa.Internal.Directive
                        Rasa.Internal.Editor

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -6,46 +6,43 @@ import Rasa.Internal.Action
 import Rasa.Internal.Events
 import Rasa.Internal.Scheduler
 
-import Control.Lens
 import Control.Concurrent.Async
+import Control.Lens
 import Control.Monad
-import Control.Monad.State
-import Control.Monad.Reader
+import Control.Monad.IO.Class
 import Data.Default (def)
-import Data.Foldable
+import Data.List
 
 -- | The main function to run rasa.
--- 
+--
 -- @rasa eventProviders extensions@
--- 
+--
 -- This should be imported by a user-config and called with extension event providers and extension event hooks as
 -- arguments. e.g.:
--- 
+--
 -- > rasa [slateEvent] $ do
 -- >   cursor
 -- >   vim
-rasa :: [Action [Keypress]] -> Scheduler () -> IO ()
-rasa eventProviders scheduler =
+rasa :: Scheduler () -> IO ()
+rasa scheduler =
   evalAction def hooks $ do
     dispatchEvent Init
-    eventLoop eventProviders
+    eventLoop
     dispatchEvent Exit
     where hooks = getHooks scheduler
 
 -- | This is the main event loop, it runs recursively forever until something
 -- sets 'Rasa.Editor.exiting'. It runs the pre-event hooks, then listens for an
 -- event from the event providers, then runs the post event hooks and repeats.
-eventLoop :: [Action [Keypress]] -> Action ()
-eventLoop eventProviders = do
+eventLoop :: Action ()
+eventLoop = do
   dispatchEvent BeforeRender
   dispatchEvent OnRender
   dispatchEvent AfterRender
   dispatchEvent BeforeEvent
-  currentEditor <- get
-  hooks <- ask
-  -- This is a little weird, but I think it needs to be this way to execute providers in parallel
-  asyncEventProviders <- liftIO $ traverse (async.evalAction currentEditor hooks) eventProviders
-  (_, nextEvents) <- liftIO $ waitAny asyncEventProviders
-  traverse_ dispatchEvent nextEvents
+  asyncActions <- use asyncs
+  (done, action) <- liftIO $ waitAny asyncActions
+  asyncs %= delete done
+  action
   isExiting <- use exiting
-  unless isExiting $ eventLoop eventProviders
+  unless isExiting eventLoop

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -17,12 +17,14 @@ import Data.List
 --
 -- @rasa eventProviders extensions@
 --
--- This should be imported by a user-config and called with extension event providers and extension event hooks as
--- arguments. e.g.:
+-- This should be imported by a user-config with and called with a 'Scheduler'
+-- containing any extensions which have event listeners.
 --
--- > rasa [slateEvent] $ do
+-- > rasa $ do
 -- >   cursor
 -- >   vim
+-- >   slate
+
 rasa :: Scheduler () -> IO ()
 rasa scheduler =
   evalAction def hooks $ do
@@ -32,8 +34,8 @@ rasa scheduler =
     where hooks = getHooks scheduler
 
 -- | This is the main event loop, it runs recursively forever until something
--- sets 'Rasa.Editor.exiting'. It runs the pre-event hooks, then listens for an
--- event from the event providers, then runs the post event hooks and repeats.
+-- sets 'Rasa.Editor.exiting'. It runs the pre-event hooks, then checks if any
+-- async events have finished, then runs the post event hooks and repeats.
 eventLoop :: Action ()
 eventLoop = do
   dispatchEvent BeforeRender

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -97,6 +97,8 @@ module Rasa.Ext
   , ext
   , bufExt
 
+  , editor
+
    -- * Accessing/Editing Context
   , Buffer
   , text
@@ -123,6 +125,7 @@ module Rasa.Ext
   , Hook
   , dispatchEvent
   , eventListener
+  , eventProvider
 
   -- * Built-in Event Hooks
   , onInit
@@ -158,6 +161,7 @@ module Rasa.Ext
   ) where
 
 import Rasa.Internal.Action
+import Rasa.Internal.Async
 import Rasa.Internal.Directive
 import Rasa.Internal.Editor
 import Rasa.Internal.Events

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -45,6 +45,7 @@ module Rasa.Ext
   (
   -- * Editor Actions
     Action
+  , doAsync
   , exit
   , addBuffer
   , addBufferThen

--- a/rasa/src/Rasa/Internal/Async.hs
+++ b/rasa/src/Rasa/Internal/Async.hs
@@ -1,6 +1,6 @@
-module Rasa.Internal.Async (
-  -- doAsync
-  eventProvider
+module Rasa.Internal.Async 
+  ( doAsync
+  , eventProvider
 ) where
 
 import Rasa.Internal.Action
@@ -11,17 +11,49 @@ import Control.Concurrent.Async
 import Control.Lens
 import Control.Monad.IO.Class
 
--- | This function takes an IO which results in some Event, it runs the IO asynchronously and dispatches the event,
--- then repeats the process all over again.
--- Use this inside the onInit scheduler to register an event listener for some event (e.g. keypresses or network
--- activity)
-eventProvider :: (Typeable a, Show a) => IO a -> Action ()
-eventProvider getEventIO = do
-  theAsync <- liftIO $ async asyncActionIO
-  asyncs <>= [theAsync]
-    where asyncActionIO = do
-            evt <- getEventIO
-            -- When this action runs, queue the same event listener recursively
-            return $ do
-              dispatchEvent evt
-              eventProvider getEventIO
+-- | This function takes an IO which results in some Event, it runs the IO
+-- asynchronously and dispatches the event, then repeats the process all over
+-- again. Use this inside the onInit scheduler to register an event listener
+-- for some event (e.g. keypresses or network activity)
+
+eventProvider :: Typeable a => IO a -> Action ()
+eventProvider getEventIO = doAsync (dispatchAndRerun <$> getEventIO)
+    where dispatchAndRerun evt = do
+            dispatchEvent evt
+            eventProvider getEventIO
+
+-- | doAsync allows you to perform a task asynchronously and then apply the
+-- result. In @doAsync asyncAction@, @asyncAction@ is an IO which resolves to
+-- an Action, note that the context in which the second action is executed is
+-- NOT the same context in which doAsync is called; it is likely that text and
+-- other state have changed while the IO executed, so it's a good idea to check
+-- (inside the applying Action) that things are in a good state before making
+-- changes. Here's an example:
+--
+-- > asyncCapitalize :: Action ()
+-- > asyncCapitalize = do
+-- >   txt <- focusDo $ use text
+-- >   -- We give doAsync an IO which resolves in an action
+-- >   doAsync $ ioPart txt
+-- >
+-- > ioPart :: Text -> IO (Action ())
+-- > ioPart txt = do
+-- >   result <- longAsyncronousCapitalizationProgram txt
+-- >   -- Note that this returns an Action, but it's still wrapped in IO
+-- >   return $ maybeApplyResult txt result
+-- >
+-- > maybeApplyResult :: Text -> Text -> Action ()
+-- > maybeApplyResult oldTxt capitalized = do
+-- >   -- We get the current buffer's text, which may have changed since we started
+-- >   newTxt <- focusDo (use text)
+-- >   if newTxt == oldTxt
+-- >     -- If the text is the same as it was, we can apply the transformation
+-- >     then focusDo (text .= capitalized)
+-- >     -- Otherwise we can choose to re-queue the whole action and try again
+-- >     -- Or we could just give up.
+-- >     else asyncCapitalize
+
+doAsync ::  IO (Action ()) -> Action ()
+doAsync asyncIO = do
+  newAsync <- liftIO $ async asyncIO
+  asyncs <>= [newAsync]

--- a/rasa/src/Rasa/Internal/Async.hs
+++ b/rasa/src/Rasa/Internal/Async.hs
@@ -1,0 +1,27 @@
+module Rasa.Internal.Async (
+  -- doAsync
+  eventProvider
+) where
+
+import Rasa.Internal.Action
+import Rasa.Internal.Scheduler
+
+import Data.Typeable
+import Control.Concurrent.Async
+import Control.Lens
+import Control.Monad.IO.Class
+
+-- | This function takes an IO which results in some Event, it runs the IO asynchronously and dispatches the event,
+-- then repeats the process all over again.
+-- Use this inside the onInit scheduler to register an event listener for some event (e.g. keypresses or network
+-- activity)
+eventProvider :: (Typeable a, Show a) => IO a -> Action ()
+eventProvider getEventIO = do
+  theAsync <- liftIO $ async asyncActionIO
+  asyncs <>= [theAsync]
+    where asyncActionIO = do
+            evt <- getEventIO
+            -- When this action runs, queue the same event listener recursively
+            return $ do
+              dispatchEvent evt
+              eventProvider getEventIO

--- a/rasa/src/Rasa/Internal/Events.hs
+++ b/rasa/src/Rasa/Internal/Events.hs
@@ -37,6 +37,7 @@ data Keypress
   | Esc
   | BS
   | Enter
+  | Unknown
   deriving (Show, Eq, Typeable)
 
 -- | This represents each modifier key that could be pressed along with a key.


### PR DESCRIPTION
Adds `doAsync` and switches the event-listener system to use the same unifying interface.

There're some really interesting ideas using `Cont` and `Free` here: https://github.com/ChrisPenner/rasa/issues/11#issuecomment-269878023

I'd still definitely like to pursue these, but this cleaned up the event system as it was anyways, so I went ahead with it for now. If me or anyone else can eventually figure out how to do the cleaner syntax presented in https://github.com/ChrisPenner/rasa/issues/11#issuecomment-269878023 then we'll integrate it later.

Let me know what you think @mitchellwrosen, as I said, I'd still love to work towards the cleaner version you presented, feel free to hack on this a bit if you have ideas for how to implement it! In the mean-time I'd love your feedback on this change.