### PR TITLE
Remove scheduler

### DIFF
--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -21,7 +21,6 @@ import Control.Monad
 
 main :: IO ()
 main = rasa $ do
-  onInit . void $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"
   views
   vim
   statusBar
@@ -30,3 +29,4 @@ main = rasa $ do
   logger
   slate
   style
+  void $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"

--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
@@ -27,5 +27,5 @@ import Rasa.Ext.Cursors.Actions
 import Rasa.Ext
 
 -- | Registers hooks for the extension. The user should add this to their config.
-cursors :: Scheduler ()
+cursors :: Action ()
 cursors = beforeRender $ buffersDo_ displayRange

--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
@@ -21,11 +21,12 @@ module Rasa.Ext.Cursors
   , moveRangesByC
   ) where
 
+import Rasa.Ext
 import Rasa.Ext.Cursors.Base
 import Rasa.Ext.Cursors.Actions
 
-import Rasa.Ext
+import Control.Monad
 
 -- | Registers hooks for the extension. The user should add this to their config.
 cursors :: Action ()
-cursors = beforeRender $ buffersDo_ displayRange
+cursors = void . beforeRender $ buffersDo_ displayRange

--- a/rasa-ext-files/src/Rasa/Ext/Files.hs
+++ b/rasa-ext-files/src/Rasa/Ext/Files.hs
@@ -37,7 +37,7 @@ instance Default FileInfo where
 files :: Action ()
 files = do 
   beforeRender showFilename
-  onInit $ do
+  void . onInit $ do
     loadFiles
     addCmd "save" $ void . focusDo . saveAs . Y.fromString
 

--- a/rasa-ext-files/src/Rasa/Ext/Files.hs
+++ b/rasa-ext-files/src/Rasa/Ext/Files.hs
@@ -34,12 +34,12 @@ instance Default FileInfo where
   _filename=Nothing
 }
 
-files :: Scheduler ()
-files = do
+files :: Action ()
+files = do 
+  beforeRender showFilename
   onInit $ do
     loadFiles
     addCmd "save" $ void . focusDo . saveAs . Y.fromString
-  beforeRender showFilename
 
 showFilename :: Action ()
 showFilename = void . focusDo $ do

--- a/rasa-ext-logger/src/Rasa/Ext/Logger.hs
+++ b/rasa-ext-logger/src/Rasa/Ext/Logger.hs
@@ -10,8 +10,8 @@ import Control.Monad.State
 
 logger :: Action ()
 logger = do
-  onInit $ liftIO $ writeFile "logs.log" "Event Log\n"
-  afterRender $ do
+  void . onInit $ liftIO $ writeFile "logs.log" "Event Log\n"
+  void . afterRender $ do
     ed <- get
     liftIO $ appendFile "logs.log" (show ed)
 

--- a/rasa-ext-logger/src/Rasa/Ext/Logger.hs
+++ b/rasa-ext-logger/src/Rasa/Ext/Logger.hs
@@ -8,7 +8,7 @@ import Rasa.Ext
 
 import Control.Monad.State
 
-logger :: Scheduler ()
+logger :: Action ()
 logger = do
   onInit $ liftIO $ writeFile "logs.log" "Event Log\n"
   afterRender $ do

--- a/rasa-ext-slate/src/Rasa/Ext/Slate.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate.hs
@@ -6,6 +6,7 @@ import Rasa.Ext.Slate.Internal.Event (terminalEvents)
 import Rasa.Ext.Slate.Internal.State (getVty)
 
 import qualified Graphics.Vty as V
+import Control.Monad
 import Control.Monad.IO.Class
 
 -- | The main export for this extension. Add this to your user config.
@@ -17,9 +18,9 @@ import Control.Monad.IO.Class
 -- >    ...
 slate :: Action ()
 slate = do
-  onInit terminalEvents
-  onRender render
-  onExit shutdown
+  void $ onInit terminalEvents
+  void $ onRender render
+  void $ onExit shutdown
 
 -- | Call vty shutdown procedure (if this doesn't happen the terminal ends up in strange states)
 shutdown :: Action ()

--- a/rasa-ext-slate/src/Rasa/Ext/Slate.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate.hs
@@ -15,7 +15,7 @@ import Control.Monad.IO.Class
 -- > rasa $ do
 -- >    slate
 -- >    ...
-slate :: Scheduler ()
+slate :: Action ()
 slate = do
   onInit terminalEvents
   onRender render

--- a/rasa-ext-status-bar/src/Rasa/Ext/StatusBar.hs
+++ b/rasa-ext-status-bar/src/Rasa/Ext/StatusBar.hs
@@ -12,6 +12,7 @@ module Rasa.Ext.StatusBar
   ) where
 
 import Control.Lens
+import Control.Monad
 
 import Data.Typeable
 import Data.Default
@@ -36,7 +37,7 @@ instance Default StatusBar where
     }
 
 statusBar :: Action ()
-statusBar = beforeEvent $ buffersDo_ clearStatus
+statusBar = void . beforeEvent $ buffersDo_ clearStatus
 
 clearStatus :: BufAction ()
 clearStatus = do

--- a/rasa-ext-status-bar/src/Rasa/Ext/StatusBar.hs
+++ b/rasa-ext-status-bar/src/Rasa/Ext/StatusBar.hs
@@ -35,7 +35,7 @@ instance Default StatusBar where
     , _right=[]
     }
 
-statusBar :: Scheduler ()
+statusBar :: Action ()
 statusBar = beforeEvent $ buffersDo_ clearStatus
 
 clearStatus :: BufAction ()

--- a/rasa-ext-style/src/Rasa/Ext/Style.hs
+++ b/rasa-ext-style/src/Rasa/Ext/Style.hs
@@ -6,6 +6,7 @@ import Control.Lens
 
 import Data.Default
 import Control.Applicative
+import Control.Monad
 
 -- | These represent the possible colors for 'fg' or 'bg'.
 -- 'DefColor' represents the terminal's default color.
@@ -87,4 +88,4 @@ addStyle r st = styles %= (Span r st:)
 -- >    style
 -- >    ...
 style :: Action ()
-style = afterRender $ buffersDo_ $ styles .= []
+style = void . afterRender $ buffersDo_ $ styles .= []

--- a/rasa-ext-style/src/Rasa/Ext/Style.hs
+++ b/rasa-ext-style/src/Rasa/Ext/Style.hs
@@ -86,5 +86,5 @@ addStyle r st = styles %= (Span r st:)
 -- > rasa $ do
 -- >    style
 -- >    ...
-style :: Scheduler ()
+style :: Action ()
 style = afterRender $ buffersDo_ $ styles .= []

--- a/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
@@ -10,7 +10,7 @@ import Data.Maybe
 import Data.List
 
 -- | Main export from the views extension, add this to your rasa config.
-views :: Scheduler ()
+views :: Action ()
 views = onBufAdded addSplit
 
 -- | Flip all Horizontal splits to Vertical ones and vice versa.

--- a/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
@@ -11,7 +11,7 @@ import Data.List
 
 -- | Main export from the views extension, add this to your rasa config.
 views :: Action ()
-views = onBufAdded addSplit
+views = void $ onBufAdded addSplit
 
 -- | Flip all Horizontal splits to Vertical ones and vice versa.
 rotate :: Action ()

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -49,9 +49,9 @@ hist = bufExt.histKeys
 vim :: Action ()
 vim = do
   -- Register to listen for keypresses
-  eventListener handleKeypress
+  void $ eventListener handleKeypress
   -- Set the status bar to the current mode before each render
-  beforeRender setStatus
+  void $ beforeRender setStatus
 
 -- | The event hook which listens for keypresses and responds appropriately
 handleKeypress :: Keypress -> Action ()

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -46,7 +46,7 @@ hist = bufExt.histKeys
 -- > rasa $ do
 -- >    vim
 -- >    ...
-vim :: Scheduler ()
+vim :: Action ()
 vim = do
   -- Register to listen for keypresses
   eventListener handleKeypress

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -25,13 +25,13 @@ import Data.List
 -- >   vim
 -- >   slate
 
-rasa :: Scheduler () -> IO ()
-rasa scheduler =
-  evalAction def hooks $ do
+rasa :: Action () -> IO ()
+rasa initilize =
+  evalAction def $ do
+    initilize
     dispatchEvent Init
     eventLoop
     dispatchEvent Exit
-    where hooks = getHooks scheduler
 
 -- | This is the main event loop, it runs recursively forever until something
 -- sets 'Rasa.Editor.exiting'. It runs the pre-event hooks, then checks if any

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -120,7 +120,6 @@ module Rasa.Ext
   , Mod(..)
 
   -- * Dealing with events
-  , Scheduler
   , Hooks
   , Hook
   , dispatchEvent
@@ -128,11 +127,11 @@ module Rasa.Ext
   , eventProvider
 
   -- * Built-in Event Hooks
-  , onInit
   , beforeEvent
   , beforeRender
   , onRender
   , afterRender
+  , onInit
   , onExit
   , onBufAdded
 

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -122,8 +122,10 @@ module Rasa.Ext
   -- * Dealing with events
   , Hooks
   , Hook
+  , HookId
   , dispatchEvent
   , eventListener
+  , removeListener
   , eventProvider
 
   -- * Built-in Event Hooks

--- a/rasa/src/Rasa/Internal/Action.hs
+++ b/rasa/src/Rasa/Internal/Action.hs
@@ -5,7 +5,6 @@ module Rasa.Internal.Action where
 import Control.Lens
 import Control.Concurrent.Async
 import Control.Monad.State
-import Control.Monad.Reader
 import Data.Dynamic
 import Data.Map
 import Data.Default
@@ -32,22 +31,23 @@ type Hooks = Map TypeRep [Hook]
 --      * Add\/Edit\/Focus buffers and a few other Editor-level things, see the 'Rasa.Internal.Ext.Directive' module.
 
 newtype Action a = Action
-  { runAct :: StateT ActionState (ReaderT Hooks IO) a
-  } deriving (Functor, Applicative, Monad, MonadState ActionState, MonadReader Hooks, MonadIO)
+  { runAct :: StateT ActionState IO a
+  } deriving (Functor, Applicative, Monad, MonadState ActionState, MonadIO)
 
 
 -- | Unwrap and execute an Action (returning the editor state)
-execAction :: ActionState -> Hooks -> Action () -> IO ActionState
-execAction actionState hooks action = flip runReaderT hooks . execStateT (runAct action) $ actionState
+execAction :: ActionState ->  Action () -> IO ActionState
+execAction actionState action = execStateT (runAct action) actionState
 
 -- | Unwrap and evaluate an Action (returning the value)
-evalAction :: ActionState -> Hooks -> Action a -> IO a
-evalAction actionState hooks action  = flip runReaderT hooks $ evalStateT (runAct action) actionState
+evalAction :: ActionState -> Action a -> IO a
+evalAction actionState action  = evalStateT (runAct action) actionState
 
 type AsyncAction = Async (Action ())
 data ActionState = ActionState
   { _ed :: Editor
   , _asyncs :: [AsyncAction]
+  , _hooks :: Hooks
   }
 makeClassy ''ActionState
 
@@ -58,6 +58,7 @@ instance Default ActionState where
   def = ActionState
     { _ed=def
     , _asyncs=def
+    , _hooks=def
     }
 
 instance Show ActionState where
@@ -74,8 +75,8 @@ instance Show ActionState where
 --      * Access/Edit the buffer's 'text'
 --
 newtype BufAction a = BufAction
-  { getBufAction::StateT Buffer (ReaderT Hooks IO) a
-  } deriving (Functor, Applicative, Monad, MonadState Buffer, MonadReader Hooks, MonadIO)
+  { getBufAction::StateT Buffer IO a
+  } deriving (Functor, Applicative, Monad, MonadState Buffer, MonadIO)
 
 -- | This lifts up a bufAction into an Action which performs the 'BufAction'
 -- over the referenced buffer and returns the result (if the buffer existed)
@@ -85,8 +86,7 @@ liftBuf bufAct (BufRef bufRef) = do
   case mBuf of
     Nothing -> return Nothing
     Just buf -> do
-      hooks <- ask
-      (val, newBuf) <- liftIO $ flip runReaderT hooks . flip runStateT buf . getBufAction $ bufAct
+      (val, newBuf) <- liftIO $ flip runStateT buf . getBufAction $ bufAct
       buffers.at bufRef ?= newBuf
       return . Just $ val
 

--- a/rasa/src/Rasa/Internal/Action.hs
+++ b/rasa/src/Rasa/Internal/Action.hs
@@ -14,7 +14,12 @@ import Rasa.Internal.Editor
 
 
 -- | A wrapper around event listeners so they can be stored in 'Hooks'.
-data Hook = forall a. Hook a
+data Hook = forall a. Hook HookId a
+data HookId =
+  HookId Int TypeRep
+
+instance Eq HookId where
+  HookId a _ == HookId b _ = a == b
 
 -- | A map of Event types to a list of listeners for that event
 type Hooks = Map TypeRep [Hook]
@@ -48,6 +53,7 @@ data ActionState = ActionState
   { _ed :: Editor
   , _asyncs :: [AsyncAction]
   , _hooks :: Hooks
+  , _nextHook :: Int
   }
 makeClassy ''ActionState
 
@@ -59,6 +65,7 @@ instance Default ActionState where
     { _ed=def
     , _asyncs=def
     , _hooks=def
+    , _nextHook=0
     }
 
 instance Show ActionState where

--- a/rasa/src/Rasa/Internal/Scheduler.hs
+++ b/rasa/src/Rasa/Internal/Scheduler.hs
@@ -1,19 +1,16 @@
-{-# LANGUAGE DeriveFunctor, GeneralizedNewtypeDeriving,
-   ExistentialQuantification, ScopedTypeVariables #-}
+{-# LANGUAGE ExistentialQuantification, ScopedTypeVariables #-}
 
 module Rasa.Internal.Scheduler
-  ( Scheduler(..)
-  , Hook
+  ( Hook
   , Hooks
   , afterRender
   , beforeEvent
   , beforeRender
   , dispatchEvent
   , eventListener
-  , getHooks
   , matchingHooks
-  , onExit
   , onInit
+  , onExit
   , onRender
   , onBufAdded
   ) where
@@ -24,39 +21,17 @@ import Rasa.Internal.Events
 import Rasa.Internal.Editor
 
 import Control.Lens
-import Control.Monad.Reader
-import Control.Monad.State
 import Data.Dynamic
 import Data.Foldable
 import Data.Map
 import Unsafe.Coerce
 
--- | The Scheduler is how you can register your extension's actions to run
--- at different points in the editor's event cycle.
---
--- The event cycle proceeds as follows:
---
--- @
---     Init  (Runs ONCE)
---
---     -- The following loops until an exit is triggered:
---     BeforeEvent -> (any event) -> BeforeRender -> OnRender -> AfterRender
---
---     Exit (Runs ONCE)
--- @
---
--- Each extension which wishes to perform actions exports a @'Scheduler' ()@
--- which the user inserts in their config file.
-newtype Scheduler a = Scheduler
-  { runSched :: State Hooks a
-  } deriving (Functor, Applicative, Monad, MonadState Hooks)
-
 -- | Use this to dispatch an event of any type, any hooks which are listening for this event will be triggered
 -- with the provided event. Use this within an Action.
 dispatchEvent :: Typeable a => a -> Action ()
 dispatchEvent evt = do
-  hooks <- ask
-  traverse_ ($ evt) (matchingHooks hooks)
+  hooks' <- use hooks
+  traverse_ ($ evt) (matchingHooks hooks')
 
 -- | This is a helper which extracts and coerces a hook from its wrapper back into the proper event handler type.
 getHook :: forall a. Hook -> (a -> Action ())
@@ -67,28 +42,26 @@ getHook = coerce
 
 -- | This extracts all event listener hooks from a map of hooks which match the type of the provided event.
 matchingHooks :: forall a. Typeable a => Hooks -> [a -> Action ()]
-matchingHooks hooks = getHook <$> (hooks^.at (typeRep (Proxy :: Proxy a))._Just)
+matchingHooks hooks' = getHook <$> (hooks'^.at (typeRep (Proxy :: Proxy a))._Just)
 
 -- | This registers an event listener hook, as long as the listener is well-typed similar to this:
 --
 -- @MyEventType -> Action ()@ then it will be registered to listen for dispatched events of that type.
 -- Use within the 'Rasa.Internal.Scheduler.Scheduler' and add have the user add it to their config.
-eventListener :: forall a. Typeable a => (a -> Action ()) -> Scheduler ()
-eventListener hook = modify $ insertWith mappend (typeRep (Proxy :: Proxy a)) [Hook hook]
-
--- | Transform a 'Rasa.Internal.Scheduler.Scheduler' monad into a 'Hooks' map.
-getHooks :: Scheduler () -> Hooks
-getHooks = flip execState mempty . runSched
-
+eventListener :: forall a. Typeable a => (a -> Action ()) -> Action ()
+eventListener hook = hooks %= insertWith mappend (typeRep (Proxy :: Proxy a)) [Hook hook]
 
 -- | Registers an action to be performed during the Initialization phase.
 --
 -- This phase occurs exactly ONCE when the editor starts up.
-onInit :: Action () -> Scheduler ()
+-- Though arbitrary actions may be performed in the configuration block;
+-- it's recommended to embed such actions in the onInit event listener
+-- so that all event listeners are registered before anything Actions occur.
+onInit :: Action () -> Action ()
 onInit action = eventListener (const action :: Init -> Action ())
 
 -- | Registers an action to be performed BEFORE each event phase.
-beforeEvent :: Action () -> Scheduler ()
+beforeEvent :: Action () -> Action ()
 beforeEvent action = eventListener (const action :: BeforeEvent -> Action ())
 
 -- | Registers an action to be performed BEFORE each render phase.
@@ -96,20 +69,20 @@ beforeEvent action = eventListener (const action :: BeforeEvent -> Action ())
 -- This is a good spot to add information useful to the renderer
 -- since all actions have been performed. Only cosmetic changes should
 -- occur during this phase.
-beforeRender :: Action () -> Scheduler ()
+beforeRender :: Action () -> Action ()
 beforeRender action = eventListener (const action :: BeforeRender -> Action ())
 
 -- | Registers an action to be performed during each render phase.
 --
 -- This phase should only be used by extensions which actually render something.
-onRender :: Action () -> Scheduler ()
+onRender :: Action () -> Action ()
 onRender action = eventListener (const action :: OnRender -> Action ())
 
 -- | Registers an action to be performed AFTER each render phase.
 --
 -- This is useful for cleaning up extension state that was registered for the
 -- renderer, but needs to be cleared before the next iteration.
-afterRender :: Action () -> Scheduler ()
+afterRender :: Action () -> Action ()
 afterRender action = eventListener (const action :: AfterRender -> Action ())
 
 -- | Registers an action to be performed during the exit phase.
@@ -118,13 +91,13 @@ afterRender action = eventListener (const action :: AfterRender -> Action ())
 -- allows an opportunity to do clean-up, kill any processes you've started, or
 -- save any data before the editor terminates.
 
-onExit :: Action () -> Scheduler ()
+onExit :: Action () -> Action ()
 onExit action = eventListener (const action :: Exit -> Action ())
 
 -- | Registers an action to be performed after a new buffer is added.
 -- 
 -- The supplied function will be called with a 'BufRef' to the new buffer, and the resulting 'Action' will be run.
-onBufAdded :: (BufRef -> Action ()) -> Scheduler ()
+onBufAdded :: (BufRef -> Action ()) -> Action ()
 onBufAdded f = eventListener listener
   where
     listener (BufAdded bRef) = f bRef


### PR DESCRIPTION
This removes the `Scheduler` Monad entirely, replacing it with a simple `Action ()`, it really wasn't doing anything interesting; and this simplifies things a bit. It also now allows extensions to register or remove listeners at any time.