### PR TITLE
Allow running `Action`s inside `BufAction` via `liftAction`

### DIFF
--- a/rasa-ext-cursors/rasa-ext-cursors.cabal
+++ b/rasa-ext-cursors/rasa-ext-cursors.cabal
@@ -1,5 +1,5 @@
 name:                rasa-ext-cursors
-version:             0.1.1
+version:             0.1.2
 synopsis:            Rasa Ext adding cursor(s)
 description:         Rasa Ext adding cursor(s)
 homepage:            https://github.com/ChrisPenner/rasa/

--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors/Base.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors/Base.hs
@@ -45,14 +45,14 @@ cleanRanges :: Y.YiString -> [Range] -> [Range]
 cleanRanges txt = fmap (ensureSize . clampRange txt) . reverse . nub . sort
 
 -- | A lens over all the stored cursor ranges for a buffer
-ranges :: Lens' Buffer [Range]
+ranges :: HasBuffer s => Lens' s [Range]
 ranges = lens getter setter
   where getter buf = buf^.bufExt.cursors
         setter buf new = let txt = buf^.text
                           in buf & bufExt.cursors .~ cleanRanges txt new
 
 -- | A Traversal over each Range for the given buffer.
-eachRange :: Traversal' Buffer Range
+eachRange :: HasBuffer s => Traversal' s Range
 eachRange = ranges.traverse
 
 -- | Sequences actions over each range as a 'BufAction'

--- a/rasa-ext-style/rasa-ext-style.cabal
+++ b/rasa-ext-style/rasa-ext-style.cabal
@@ -1,5 +1,5 @@
 name:                rasa-ext-style
-version:             0.1.1
+version:             0.1.2
 synopsis:            Rasa Ext managing rendering styles
 description:         Rasa Ext managing rendering styles
 homepage:            https://github.com/ChrisPenner/rasa/

--- a/rasa-ext-style/src/Rasa/Ext/Style.hs
+++ b/rasa-ext-style/src/Rasa/Ext/Style.hs
@@ -58,7 +58,7 @@ newtype Styles =
 makeLenses ''Styles
 
 -- | A lens over the styles stored in the current buffer.
-styles :: Lens' Buffer [Span Style]
+styles :: HasBuffer s => Lens' s [Span Style]
 styles = bufExt.styles'
 
 instance Default Styles where

--- a/rasa-ext-views/src/Rasa/Ext/Views.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views.hs
@@ -17,6 +17,7 @@ module Rasa.Ext.Views
   , A.nextBuf
   , A.prevBuf
   , A.focusDo
+  , A.focusDo_
   , A.focusedBufs
   , Dir(..)
   , SplitRule(..)

--- a/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
@@ -87,3 +87,6 @@ focusDo :: BufAction a -> Action [a]
 focusDo bufAct = do
   bufRefs <- focusedBufs
   catMaybes <$> mapM (`bufDo` bufAct) bufRefs
+
+focusDo_ :: BufAction a -> Action ()
+focusDo_ = void . focusDo

--- a/rasa-ext-vim/rasa-ext-vim.cabal
+++ b/rasa-ext-vim/rasa-ext-vim.cabal
@@ -1,5 +1,5 @@
 name:                rasa-ext-vim
-version:             0.1.1
+version:             0.1.2
 synopsis:            Rasa Ext for vim bindings
 description:         Rasa Ext for vim bindings
 homepage:            https://github.com/ChrisPenner/rasa/

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -1,5 +1,5 @@
 name:                rasa
-version:             0.1.5
+version:             0.1.6
 synopsis:            A modular text editor
 homepage:            https://github.com/ChrisPenner/rasa#readme
 license:             MIT

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -58,6 +58,7 @@ module Rasa.Ext
 
   -- * Working with Buffers
   , BufAction
+  , liftAction
   , bufDo
   , bufDo_
   , buffersDo
@@ -108,6 +109,7 @@ module Rasa.Ext
 
    -- * Accessing/Editing Context
   , Buffer
+  , HasBuffer
   , BufRef
   , HasEditor
   , text

--- a/rasa/src/Rasa/Internal/Action.hs
+++ b/rasa/src/Rasa/Internal/Action.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ExistentialQuantification, TemplateHaskell, StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, ExistentialQuantification, TemplateHaskell, StandaloneDeriving,
+   MultiParamTypeClasses, FlexibleInstances #-}
 
 module Rasa.Internal.Action where
 
@@ -32,30 +33,37 @@ type Hooks = Map TypeRep [Hook]
 --      * Use liftIO for IO
 --      * Access/edit extensions that are stored globally, see 'ext'
 --      * Embed any 'Action's exported other extensions
---      * Embed buffer actions using 'Rasa.Internal.Ext.Directive.bufDo' and 'Rasa.Internal.Ext.Directive.focusDo'
+--      * Embed buffer actions using 'Rasa.Internal.Ext.Directive.bufDo' or 'Rasa.Internal.Ext.Directive.buffersDo'
 --      * Add\/Edit\/Focus buffers and a few other Editor-level things, see the 'Rasa.Internal.Ext.Directive' module.
 
 newtype Action a = Action
   { runAct :: StateT ActionState IO a
   } deriving (Functor, Applicative, Monad, MonadState ActionState, MonadIO)
 
-
--- | Unwrap and execute an Action (returning the editor state)
+-- | Execute an Action (returning the editor state)
 execAction :: ActionState ->  Action () -> IO ActionState
 execAction actionState action = execStateT (runAct action) actionState
 
--- | Unwrap and evaluate an Action (returning the value)
+-- | Evaluate an Action (returning the value)
 evalAction :: ActionState -> Action a -> IO a
-evalAction actionState action  = evalStateT (runAct action) actionState
+evalAction actionState (Action action)  = evalStateT action actionState
 
 type AsyncAction = Async (Action ())
+-- | This contains all data representing the editor's state. It acts as the state object for an 'Action
 data ActionState = ActionState
   { _ed :: Editor
   , _asyncs :: [AsyncAction]
   , _hooks :: Hooks
   , _nextHook :: Int
   }
-makeClassy ''ActionState
+makeLenses ''ActionState
+
+-- | Allows polymorphic lenses which need to access something in ActionState
+class HasActionState a where
+  actionState :: Lens' a ActionState
+
+instance HasActionState ActionState where
+  actionState = lens id (flip const)
 
 instance HasEditor ActionState where
   editor = ed
@@ -68,32 +76,60 @@ instance Default ActionState where
     , _nextHook=0
     }
 
+-- | Contains all data about the editor; as well as a buffer which is in 'focus'.
+-- We keep the full ActionState here too so that 'Action's may be lifted inside a 'BufAction'
+data BufActionState = BufActionState
+  { _actState :: ActionState
+  , _buf :: Buffer
+  }
+makeLenses ''BufActionState
+
 instance Show ActionState where
   show as = show (_ed as)
 
 -- | This is a monad-transformer stack for performing actions on a specific buffer.
--- You register BufActions to be run by embedding them in a scheduled 'Action' via 'bufferDo' or 'focusDo'
+-- You run 'BufAction's by embedding them in a 'Action' via 'bufferDo' or 'buffersDo'
 --
 -- Within a BufAction you can:
 --
+--      * Use 'liftAction' to run an 'Action'; It is your responsibility to ensure that any nested 'Action's don't edit
+  --      the Buffer which the current 'BufAction' is editing; behaviour is undefined if this occurs.
 --      * Use liftIO for IO
---      * Access/edit buffer extensions; see 'bufExt'
---      * Embed and sequence any 'BufAction's from other extensions
 --      * Access/Edit the buffer's 'text'
---
+--      * Access/edit buffer extensions; see 'bufExt'
+--      * Embed and sequence 'BufAction's from other extensions
+
 newtype BufAction a = BufAction
-  { getBufAction::StateT Buffer IO a
-  } deriving (Functor, Applicative, Monad, MonadState Buffer, MonadIO)
+  { runBufAct :: StateT BufActionState IO a
+  } deriving (Functor, Applicative, Monad, MonadState BufActionState, MonadIO)
+
+instance HasBuffer BufActionState where
+  buffer = buf
+
+instance HasActionState BufActionState where
+  actionState = actState
 
 -- | This lifts up a bufAction into an Action which performs the 'BufAction'
 -- over the referenced buffer and returns the result (if the buffer existed)
 liftBuf :: BufAction a -> BufRef -> Action (Maybe a)
-liftBuf bufAct (BufRef bufRef) = do
-  mBuf <- use (buffers.at bufRef)
+liftBuf (BufAction bufAct) (BufRef bufInd) = do
+  actionState' <- get
+  mBuf <- getBuffer
   case mBuf of
     Nothing -> return Nothing
-    Just buf -> do
-      (val, newBuf) <- liftIO $ flip runStateT buf . getBufAction $ bufAct
-      buffers.at bufRef ?= newBuf
-      return . Just $ val
+    Just b -> do
+      let bufActSt = BufActionState actionState' b
+      (val, newBufActState) <- liftIO $ runStateT bufAct bufActSt
+      put (newBufActState^.actionState)
+      setBuffer (newBufActState^.buf)
+      return (Just val)
+  where
+    getBuffer = use (buffers.at bufInd)
+    setBuffer b = buffers.at bufInd ?= b
 
+-- | This lifts up an 'Action' to be run inside a 'BufAction'
+--
+-- it is your responsibility to ensure that any nested 'Action's don't edit
+-- the Buffer which the current 'BufAction' is editing; behaviour is undefined if this occurs.
+liftAction :: Action a -> BufAction a
+liftAction (Action action) = BufAction $ zoom actionState action

--- a/rasa/src/Rasa/Internal/Buffer.hs
+++ b/rasa/src/Rasa/Internal/Buffer.hs
@@ -1,14 +1,20 @@
-{-# LANGUAGE Rank2Types, TemplateHaskell, OverloadedStrings, ExistentialQuantification, ScopedTypeVariables,
-   GeneralizedNewtypeDeriving, FlexibleInstances,
-   StandaloneDeriving #-}
+{-# language
+     Rank2Types
+  , TemplateHaskell
+  , OverloadedStrings
+  , ExistentialQuantification
+  , ScopedTypeVariables
+  , GeneralizedNewtypeDeriving
+  , FlexibleInstances
+  , StandaloneDeriving
+  #-}
 
 module Rasa.Internal.Buffer
   ( Buffer
-  , Ext(..)
-  , bufExts
-  -- | A lens over the extensions stored for a buffer
+  , HasBuffer(..)
   , text
--- | A lens into the text of the given buffer. Use within a BufAction.
+  , bufExt
+  , Ext(..)
   , mkBuffer
   ) where
 
@@ -17,25 +23,66 @@ import Rasa.Internal.Extensions
 import qualified Yi.Rope as Y
 import Control.Lens hiding (matching)
 import Data.Map
+import Data.Typeable
+import Data.Default
+import Data.Maybe
+import Unsafe.Coerce
 
 -- | A buffer, holds the text in the buffer and any extension states that are set on the buffer.
--- A buffer is the State of the 'Rasa.Internal.Action.BufAction' monad transformer stack,
--- so the type may be useful in defining lenses over your extension states.
 data Buffer = Buffer
-  { _text :: Y.YiString
-  , _bufExts :: ExtMap
+  { _text' :: Y.YiString
+  , _bufExts' :: ExtMap
   }
-
 makeLenses ''Buffer
 
 instance Show Buffer where
   show b = "<Buffer {text:" ++ show (b^..text . to (Y.take 30)) ++ "...,\n"
            ++ "exts: " ++ show (b^.bufExts) ++ "}>\n"
 
--- | Creates a new buffer from the givven text.
+-- | This allows creation of polymorphic lenses over any type which has access to a Buffer
+class HasBuffer a where
+  buffer :: Lens' a Buffer
+
+instance HasBuffer Buffer where
+  buffer = lens id (flip const)
+
+-- | This lens focuses the text of the in-scope buffer.
+text :: HasBuffer b => Lens' b Y.YiString
+text = buffer.text'
+
+-- | This lens focuses the Extensions States map of the in-scope buffer.
+bufExts :: HasBuffer b => Lens' b ExtMap
+bufExts = buffer.bufExts'
+
+-- | 'bufExt' is a lens which will focus a given extension's state within a
+-- buffer (within a 'Data.Action.BufAction'). The lens will automagically focus
+-- the required extension by using type inference. It's a little bit of magic,
+-- if you treat the focus as a member of your extension state it should just
+-- work out.
+--
+-- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
+-- nothing has yet been stored.
+
+bufExt
+  :: forall a s.
+    (Show a, Typeable a, Default a, HasBuffer s)
+    => Lens' s a
+bufExt = lens getter setter
+  where
+    getter buf =
+      fromMaybe def $ buf ^. bufExts . at (typeRep (Proxy :: Proxy a)) .
+      mapping coerce
+    setter buf new =
+      set
+        (bufExts . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
+        (Just new)
+        buf
+    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext
+
+-- | Creates a new buffer from the given text.
 mkBuffer :: Y.YiString -> Buffer
 mkBuffer txt =
   Buffer
-    { _text = txt
-    , _bufExts = empty
+    { _text' = txt
+    , _bufExts' = empty
     }

--- a/rasa/src/Rasa/Internal/Editor.hs
+++ b/rasa/src/Rasa/Internal/Editor.hs
@@ -1,34 +1,26 @@
-{-# LANGUAGE TemplateHaskell, Rank2Types,
-  ExistentialQuantification, ScopedTypeVariables,
-  OverloadedStrings
+{-# language
+    TemplateHaskell
+  , Rank2Types
+  , ExistentialQuantification
+  , ScopedTypeVariables
+  , OverloadedStrings
   #-}
 
 module Rasa.Internal.Editor
   (
   -- * Accessing/Storing state
   Editor
-  , HasEditor
-  , editor
+  , HasEditor(..)
   , buffers
-
--- |'buffers' is a lens into all buffers.
-
   , exiting
-
--- | 'exiting' Whether the editor is in the process of exiting. Can be set inside an 'Rasa.Internal.Action.Action':
---
--- > exiting .= True
-
   , ext
   , bufExt
   , nextBufId
-  , range
   , BufRef(..)
   ) where
 
 import Rasa.Internal.Buffer
 import Rasa.Internal.Extensions
-import Rasa.Internal.Range
 
 import Unsafe.Coerce
 import Data.Dynamic
@@ -36,7 +28,6 @@ import Data.Default
 import Data.Maybe
 import Data.IntMap
 import Control.Lens
-import qualified Yi.Rope as Y
 
 -- | An opaque reference to a buffer (The contained Int is not meant to be
 -- altered). It is possible for references to become stale if buffers are
@@ -48,12 +39,12 @@ newtype BufRef =
 
 -- | This is the primary state of the editor.
 data Editor = Editor
-  { _buffers :: IntMap Buffer
-  , _exiting :: Bool
-  , _extState :: ExtMap
-  , _nextBufId :: Int
+  { _buffers' :: IntMap Buffer
+  , _exiting' :: Bool
+  , _extState' :: ExtMap
+  , _nextBufId' :: Int
   }
-makeClassy ''Editor
+makeLenses ''Editor
 
 instance Show Editor where
   show ed =
@@ -61,40 +52,37 @@ instance Show Editor where
     ++ "Editor Extensions==============\n" ++ show (ed^.extState) ++ "\n\n"
     ++ "---\n\n"
 
+-- | This allows polymorphic lenses over anything that has access to an Editor context
+class HasEditor a where
+  editor :: Lens' a Editor
+
+-- | A lens over the map of available buffers
+buffers :: HasEditor e => Lens' e (IntMap Buffer)
+buffers = editor.buffers'
+
+-- | A lens over the exiting status of the editor
+exiting :: HasEditor e => Lens' e Bool
+exiting = editor.exiting'
+
+-- | A lens over the extension state of 'Editor' level extensions
+extState :: HasEditor e => Lens' e ExtMap
+extState = editor.extState'
+
+-- | A lens over the next buffer id to be allocated
+nextBufId :: HasEditor e => Lens' e Int
+nextBufId = editor.nextBufId'
+
+instance HasEditor Editor where
+  editor = lens id (flip const)
 
 instance Default Editor where
   def =
     Editor
-    { _extState = def
-    , _buffers=empty
-    , _exiting=False
-    , _nextBufId=0
+    { _extState'=def
+    , _buffers'=empty
+    , _exiting'=False
+    , _nextBufId'=0
     }
-
--- | 'bufExt' is a lens which will focus a given extension's state within a
--- buffer (within a 'Data.Action.BufAction'). The lens will automagically focus
--- the required extension by using type inference. It's a little bit of magic,
--- if you treat the focus as a member of your extension state it should just
--- work out.
---
--- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
--- nothing has yet been stored.
-
-bufExt
-  :: forall a.
-     (Show a, Typeable a, Default a)
-    => Lens' Buffer a
-bufExt = lens getter setter
-  where
-    getter buf =
-      fromMaybe def $ buf ^. bufExts . at (typeRep (Proxy :: Proxy a)) .
-      mapping coerce
-    setter buf new =
-      set
-        (bufExts . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
-        (Just new)
-        buf
-    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext
 
 -- | 'ext' is a lens which will focus the extension state that matches the type
 -- inferred as the focal point. It's a little bit of magic, if you treat the
@@ -118,9 +106,3 @@ ext = lens getter setter
         (Just new)
         ed
     coerce = iso (\(Ext x) -> unsafeCoerce x) Ext
-
--- | A lens over text which is encompassed by a 'Range'
-range :: Range -> Lens' Buffer Y.YiString
-range (Range start end) = lens getter setter
-  where getter = view (text . beforeC end . afterC start)
-        setter old new = old & text . beforeC end . afterC start .~ new

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -6,6 +6,7 @@ module Rasa.Internal.Range
   , clampCoord
   , clampRange
   , Range(..)
+  , range
   , sizeOf
   , sizeOfR
   , moveRange
@@ -18,6 +19,8 @@ module Rasa.Internal.Range
   , beforeC
   , afterC
   ) where
+
+import Rasa.Internal.Buffer
 
 import Control.Lens
 import Data.Maybe
@@ -192,3 +195,9 @@ afterC c@(Coord row col) = lens getter setter
 
         setter old new = let prefix = old ^. beforeC c
                           in prefix <> new
+
+-- | A lens over text which is encompassed by a 'Range'
+range :: HasBuffer s =>  Range -> Lens' s Y.YiString
+range (Range start end) = lens getter setter
+  where getter = view (text . beforeC end . afterC start)
+        setter old new = old & text . beforeC end . afterC start .~ new


### PR DESCRIPTION
Do some clever lens polymorphism to allow Actions to work in the context of a BufAction.

Note that there's one place where this could go wrong; the state of the focused buffer is kept alongside the Editor state as WELL as in the `buffers` map; if it's edited within the `buffers` map somehow (only way right now is to embed a BufAction inside an Action inside a BufAction; which is unlikely but possible) then behaviour is undefined and likely some changes would be lost. It should be fixable later; but this'll do fine for now!