### PR TITLE
Convert Action and BufAction Free monads

### DIFF
--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors.hs
@@ -11,9 +11,9 @@ module Rasa.Ext.Cursors
   , findPrevFrom
 
   -- * Working with Cursor Ranges
-  , eachRange
   , addRange
-  , ranges
+  , getRanges
+  , setRanges
   , rangeDo
   , rangeDo_
   , overRanges

--- a/rasa-ext-files/src/Rasa/Ext/Files.hs
+++ b/rasa-ext-files/src/Rasa/Ext/Files.hs
@@ -47,7 +47,7 @@ showFilename = focusDo_ $ do
       where disp name = "<" <> name <> ">"
 
 saveAs :: Y.YiString -> BufAction ()
-saveAs fName = use getText >>= liftIO . TIO.writeFile (Y.toString fName) . Y.toText
+saveAs fName = getText >>= liftIO . TIO.writeFile (Y.toString fName) . Y.toText
 
 save :: BufAction ()
 save = do

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
@@ -84,7 +84,7 @@ renderView (width, height) (vw, buf) = appendActiveBar . resize . addEndBar $ te
     textImage :: V.Image
     textImage = applyAttrs adjustedStyles txt
     txt :: Y.YiString
-    txt = buf^.getText & trimText
+    txt = buf^.text & trimText
     adjustedStyles :: [Span CrdRange V.Attr]
     adjustedStyles = bimap adjustStylePositions convertStyle <$> buf^.styles
     adjustStylePositions :: CrdRange -> CrdRange

--- a/rasa-ext-style/src/Rasa/Ext/Style.hs
+++ b/rasa-ext-style/src/Rasa/Ext/Style.hs
@@ -57,7 +57,7 @@ newtype Styles =
 makeLenses ''Styles
 
 -- | A lens over the styles stored in the current buffer.
-styles :: HasBuffer s => Lens' s [Span CrdRange Style]
+styles :: HasBufExts s => Lens' s [Span CrdRange Style]
 styles = bufExt.styles'
 
 instance Default Styles where

--- a/rasa-ext-views/src/Rasa/Ext/Views/Internal/Views.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views/Internal/Views.hs
@@ -93,7 +93,7 @@ data Views = Views
 makeLenses ''Views
 
 -- | A lens to access the stored windows
-windows :: HasEditor e => Lens' e (Maybe Window)
+windows :: HasExts e => Lens' e (Maybe Window)
 windows = ext.windows'
 
 instance Default Views where

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -65,6 +65,7 @@ library
                        Rasa.Internal.Range
                        Rasa.Internal.Scheduler
                        Rasa.Internal.Text
+                       Rasa.Internal.BufAction
 
   ghc-options:         -Wall
   build-depends:       base >= 4.8 && < 5
@@ -72,6 +73,7 @@ library
                      , bifunctors
                      , containers
                      , data-default
+                     , free
                      , lens
                      , mtl
                      , text

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -98,12 +98,14 @@ module Rasa.Ext
   -- Since it's polymorphic, if ghc can't figure out the type the result is
   -- supposed to be then you'll need to help it out. In practice you won't
   -- typically need to do this unless you're doing something complicated.
-
+  , HasExts(..)
   , ext
+  , HasBufExts(..)
   , bufExt
 
    -- * Accessing/Editing Context
   , Buffer
+  , text
   , HasBuffer
   , BufRef
   , HasEditor
@@ -177,10 +179,12 @@ module Rasa.Ext
 
 import Rasa.Internal.Action
 import Rasa.Internal.Async
+import Rasa.Internal.Buffer
 import Rasa.Internal.Directive
 import Rasa.Internal.Editor
+import Rasa.Internal.Extensions
 import Rasa.Internal.Events
-import Rasa.Internal.Buffer
-import Rasa.Internal.Text
+import Rasa.Internal.BufAction
 import Rasa.Internal.Range
 import Rasa.Internal.Scheduler
+import Rasa.Internal.Text

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -105,8 +105,8 @@ module Rasa.Ext
 
    -- * Accessing/Editing Context
   , Buffer
+  , HasBuffer(..)
   , text
-  , HasBuffer
   , BufRef
   , HasEditor
   , getText

--- a/rasa/src/Rasa/Internal/Action.hs
+++ b/rasa/src/Rasa/Internal/Action.hs
@@ -1,9 +1,15 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ExistentialQuantification, TemplateHaskell, StandaloneDeriving,
-   MultiParamTypeClasses, FlexibleInstances #-}
-
+{-# language DeriveFunctor
+  , MultiParamTypeClasses
+  , FlexibleInstances
+  , GeneralizedNewtypeDeriving
+  , Rank2Types
+  , ExistentialQuantification
+  , TemplateHaskell #-}
 module Rasa.Internal.Action
-  ( Action
-  , runAct
+  ( Action(..)
+  , runAction
+  , evalAction
+  , execAction
   , ActionState
   , Hook(..)
   , HookId(..)
@@ -11,21 +17,19 @@ module Rasa.Internal.Action
   , hooks
   , nextHook
   , asyncs
-  , evalAction
-  , execAction
-  , runAction
   ) where
-
-import Control.Lens
-import Control.Concurrent.Async
-import Control.Monad.State
-import Data.Dynamic
-import Data.Map
-import Data.Default
 
 import Rasa.Internal.Editor
 import Rasa.Internal.Extensions
 
+import Control.Lens
+import Control.Monad.Free
+import Control.Monad.State
+import Control.Concurrent.Async
+
+import Data.Default
+import Data.Map
+import Data.Typeable
 
 -- | A wrapper around event listeners so they can be stored in 'Hooks'.
 data Hook = forall a. Hook HookId (a -> Action ())
@@ -38,8 +42,14 @@ instance Eq HookId where
 -- | A map of Event types to a list of listeners for that event
 type Hooks = Map TypeRep [Hook]
 
--- | This is a monad-transformer stack for performing actions against the editor.
--- You register Actions to be run in response to events using 'Rasa.Internal.Scheduler.onEveryTrigger'
+-- | Free Monad Actions for Action
+data ActionF state next =
+  LiftState (state -> (next, state))
+  | LiftIO (IO next)
+  deriving (Functor)
+
+-- | This is a monad for performing actions against the editor.
+-- You can register Actions to be run in response to events using 'Rasa.Internal.Scheduler.onEveryTrigger'
 --
 -- Within an Action you can:
 --
@@ -48,22 +58,9 @@ type Hooks = Map TypeRep [Hook]
 --      * Embed any 'Action's exported other extensions
 --      * Embed buffer actions using 'Rasa.Internal.Ext.Directive.bufDo' or 'Rasa.Internal.Ext.Directive.buffersDo'
 --      * Add\/Edit\/Focus buffers and a few other Editor-level things, see the 'Rasa.Internal.Ext.Directive' module.
-
 newtype Action a = Action
-  { runAct :: StateT ActionState IO a
-  } deriving (Functor, Applicative, Monad, MonadState ActionState, MonadIO)
-
--- | Execute an Action (returning the editor state)
-execAction :: ActionState ->  Action () -> IO ActionState
-execAction actionState action = execStateT (runAct action) actionState
-
--- | Evaluate an Action (returning the value)
-evalAction :: ActionState -> Action a -> IO a
-evalAction actionState (Action action)  = evalStateT action actionState
-
--- | Run an Action (returning the value)
-runAction :: Action a -> ActionState -> IO (a, ActionState)
-runAction action = runStateT (runAct action)
+  { getAction :: Free (ActionF ActionState) a
+  } deriving (Functor, Applicative, Monad)
 
 type AsyncAction = Async (Action ())
 
@@ -76,11 +73,8 @@ data ActionState = ActionState
   }
 makeLenses ''ActionState
 
-instance HasEditor ActionState where
-  editor = ed
-
-instance HasExts ActionState where
-  exts = ed.exts
+instance Show ActionState where
+  show as = show (_ed as)
 
 instance Default ActionState where
   def = ActionState
@@ -90,5 +84,51 @@ instance Default ActionState where
     , _nextHook=0
     }
 
-instance Show ActionState where
-  show as = show (_ed as)
+instance HasEditor ActionState where
+  editor = ed
+
+instance HasExts ActionState where
+  exts = ed.exts
+
+-- | Embeds a ActionF type into the Action Monad
+liftActionF :: ActionF ActionState a -> Action a
+liftActionF = Action . liftF
+
+-- | Allows running state actions over ActionState; used to lift mtl state functions
+liftState :: (ActionState -> (a, ActionState)) -> Action a
+liftState = liftActionF . LiftState
+
+-- | Allows running IO in BufAction.
+liftFIO :: IO r -> Action r
+liftFIO = liftActionF . LiftIO
+
+instance (MonadState ActionState) Action where
+  state = liftState
+
+instance MonadIO Action where
+  liftIO = liftFIO
+
+-- | Runs an Action into an IO
+runAction :: ActionState -> Action a -> IO (a, ActionState)
+runAction actionState (Action actionF) = actionInterpreter actionState actionF
+
+-- | Evals an Action into an IO
+evalAction :: ActionState -> Action a -> IO a
+evalAction actionState action = fst <$> runAction actionState action
+
+-- | Execs an Action into an IO
+execAction :: ActionState -> Action a -> IO ActionState
+execAction actionState action = snd <$> runAction actionState action
+
+-- | Interpret the Free Monad; in this case it interprets it down to an IO
+actionInterpreter :: ActionState -> Free (ActionF ActionState) r -> IO (r, ActionState)
+actionInterpreter actionState (Free actionF) =
+  case actionF of
+    (LiftState stateFunc) -> 
+      let (next, newState) = stateFunc actionState
+       in actionInterpreter newState next
+
+    (LiftIO ioNext) ->
+      ioNext >>= actionInterpreter actionState
+
+actionInterpreter actionState (Pure res) = return (res, actionState)

--- a/rasa/src/Rasa/Internal/BufAction.hs
+++ b/rasa/src/Rasa/Internal/BufAction.hs
@@ -1,0 +1,155 @@
+{-# language DeriveFunctor
+  , MultiParamTypeClasses
+  , FlexibleInstances
+  , GeneralizedNewtypeDeriving
+  , Rank2Types
+  , TemplateHaskell #-}
+module Rasa.Internal.BufAction
+  ( BufAction(..)
+  , getText
+  , setText
+  , getRange
+  , setRange
+  , overRange
+  , liftState
+  , liftAction
+  , runBufAction
+  ) where
+
+import Rasa.Internal.Buffer
+import Rasa.Internal.Editor
+import Rasa.Internal.Action
+import Rasa.Internal.Range
+import Rasa.Internal.Scheduler
+import Rasa.Internal.Events
+import Rasa.Internal.Extensions
+
+import Control.Lens
+import Control.Monad.Free
+import Control.Monad.State
+
+import qualified Yi.Rope as Y
+
+-- | Contains all data about the editor; as well as a buffer which is in 'focus'.
+-- We keep the full ActionState here too so that 'Action's may be lifted inside a 'BufAction'
+data BufActionState = BufActionState
+  { _buffer' :: Buffer
+  , _actionState :: ActionState
+  }
+makeLenses ''BufActionState
+
+instance HasBufExts BufActionState where
+  bufExts = buffer'.bufExts
+
+-- | Free Monad Actions for BufAction
+data BufActionF state next =
+      GetText (Y.YiString -> next)
+    | SetText Y.YiString next
+    | SetRange CrdRange Y.YiString next
+    | LiftState (state -> (next, state))
+    | LiftIO (IO next)
+  deriving (Functor)
+
+-- | Embeds a BufActionF type into the BufAction Monad
+liftBufAction :: BufActionF BufActionState a -> BufAction a
+liftBufAction = BufAction . liftF
+
+-- | Returns the text of the current buffer
+getText :: BufAction Y.YiString
+getText = liftBufAction $ GetText id
+
+-- | Sets the text of the current buffer
+setText :: Y.YiString -> BufAction ()
+setText txt = liftBufAction $ SetText txt ()
+
+-- | Gets the range of text from the buffer
+getRange :: CrdRange -> BufAction Y.YiString
+getRange rng = view (range rng) <$> getText
+
+-- | Sets the range of text from the buffer
+setRange :: CrdRange -> Y.YiString -> BufAction ()
+setRange rng txt = liftBufAction $ SetRange rng txt ()
+
+-- | Runs function over given range of text
+overRange :: CrdRange -> (Y.YiString -> Y.YiString) -> BufAction ()
+overRange r f = getRange r >>= setRange r . f
+
+-- | Allows running state actions over BufActionState; used to lift mtl state functions
+liftState :: (BufActionState -> (a, BufActionState)) -> BufAction a
+liftState = liftBufAction . LiftState
+
+-- | Allows running IO in BufAction.
+liftFIO :: IO r -> BufAction r
+liftFIO = liftBufAction . LiftIO
+
+-- | This is a monad-transformer stack for performing actions on a specific buffer.
+-- You run 'BufAction's by embedding them in a 'Action' via 'bufferDo' or 'buffersDo'
+--
+-- Within a BufAction you can:
+--
+--      * Use 'liftAction' to run an 'Action'; It is your responsibility to ensure that any nested 'Action's don't edit
+  --      the Buffer which the current 'BufAction' is editing; behaviour is undefined if this occurs.
+--      * Use liftIO for IO
+--      * Access/Edit the buffer's text
+--      * Access/edit buffer extensions; see 'bufExt'
+--      * Embed and sequence 'BufAction's from other extensions
+newtype BufAction a = BufAction
+  { getBufAction :: Free (BufActionF BufActionState) a
+  } deriving (Functor, Applicative, Monad)
+
+instance (MonadState BufActionState) BufAction where
+  state = liftState
+
+instance MonadIO BufAction where
+  liftIO = liftFIO
+
+-- | This lifts up an 'Action' to be run inside a 'BufAction'
+liftAction :: Action r -> BufAction r
+liftAction action = do
+  actState <- use actionState
+  (res, endState) <- liftIO $ runAction action actState
+  actionState .= endState
+  return res
+
+bufAt :: BufRef -> Traversal' ActionState Buffer
+bufAt (BufRef bufInd) = buffers.at bufInd._Just
+
+-- | This lifts up a bufAction into an Action which performs the 'BufAction'
+-- over the referenced buffer and returns the result (if the buffer existed)
+runBufAction :: BufAction a -> BufRef -> Action (Maybe a)
+runBufAction (BufAction bufActF) = flip bufActionInterpreter bufActF
+
+-- | Interpret the Free Monad; in this case it interprets it down to an Action.
+bufActionInterpreter :: BufRef -> Free (BufActionF BufActionState) r -> Action (Maybe r)
+bufActionInterpreter bRef (Free bufActionF) =
+  case bufActionF of
+    (GetText nextF) -> do
+      actState <- get
+      case actState^? bufAt bRef of
+        Nothing -> return Nothing
+        Just buf -> bufActionInterpreter bRef (nextF (buf^.text))
+
+    (SetText newText next) -> do
+      bufAt bRef.text .= newText
+      bufActionInterpreter bRef next
+
+    (SetRange rng newText next) -> do
+      bufAt bRef.text.range rng .= newText
+      dispatchEvent $ BufTextChanged rng newText
+      bufActionInterpreter bRef next
+
+    (LiftState stateFunc) -> do
+      mBuf <- preuse (bufAt bRef)
+      case mBuf of
+        Nothing -> return Nothing
+        Just buf -> do
+          actState <- get
+          let (next, BufActionState newBuf newActState) = stateFunc (BufActionState buf actState)
+          put newActState
+          bufAt bRef .= newBuf
+          bufActionInterpreter bRef next
+
+    (LiftIO ioNext) ->
+      liftIO ioNext >>= bufActionInterpreter bRef
+
+bufActionInterpreter _ (Pure res) = return $ Just res

--- a/rasa/src/Rasa/Internal/BufAction.hs
+++ b/rasa/src/Rasa/Internal/BufAction.hs
@@ -82,7 +82,7 @@ liftState = liftBufAction . LiftState
 liftFIO :: IO r -> BufAction r
 liftFIO = liftBufAction . LiftIO
 
--- | This is a monad-transformer stack for performing actions on a specific buffer.
+-- | This is a monad for performing actions on a specific buffer.
 -- You run 'BufAction's by embedding them in a 'Action' via 'bufferDo' or 'buffersDo'
 --
 -- Within a BufAction you can:
@@ -107,7 +107,7 @@ instance MonadIO BufAction where
 liftAction :: Action r -> BufAction r
 liftAction action = do
   actState <- use actionState
-  (res, endState) <- liftIO $ runAction action actState
+  (res, endState) <- liftIO $ runAction actState action
   actionState .= endState
   return res
 

--- a/rasa/src/Rasa/Internal/Buffer.hs
+++ b/rasa/src/Rasa/Internal/Buffer.hs
@@ -13,9 +13,6 @@ module Rasa.Internal.Buffer
   ( Buffer
   , HasBuffer(..)
   , text
-  , getText
-  , bufExt
-  , Ext(..)
   , mkBuffer
   ) where
 
@@ -24,10 +21,6 @@ import Rasa.Internal.Extensions
 import qualified Yi.Rope as Y
 import Control.Lens hiding (matching)
 import Data.Map
-import Data.Typeable
-import Data.Default
-import Data.Maybe
-import Unsafe.Coerce
 
 -- | A buffer, holds the text in the buffer and any extension states that are set on the buffer.
 data Buffer = Buffer
@@ -35,6 +28,9 @@ data Buffer = Buffer
   , _bufExts' :: ExtMap
   }
 makeLenses ''Buffer
+
+instance HasBufExts Buffer where
+  bufExts = bufExts'
 
 instance Show Buffer where
   show b = "<Buffer {text:" ++ show (b^..text . to (Y.take 30)) ++ "...,\n"
@@ -50,39 +46,6 @@ instance HasBuffer Buffer where
 -- | This lens focuses the text of the in-scope buffer.
 text :: HasBuffer b => Lens' b Y.YiString
 text = buffer.text'
-
--- | This getter-lens focuses the text of the in-scope buffer.
-getText :: HasBuffer b => Getting r b Y.YiString
-getText = buffer.text'
-  
--- | This lens focuses the Extensions States map of the in-scope buffer.
-bufExts :: HasBuffer b => Lens' b ExtMap
-bufExts = buffer.bufExts'
-
--- | 'bufExt' is a lens which will focus a given extension's state within a
--- buffer (within a 'Data.Action.BufAction'). The lens will automagically focus
--- the required extension by using type inference. It's a little bit of magic,
--- if you treat the focus as a member of your extension state it should just
--- work out.
---
--- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
--- nothing has yet been stored.
-
-bufExt
-  :: forall a s.
-    (Show a, Typeable a, Default a, HasBuffer s)
-    => Lens' s a
-bufExt = lens getter setter
-  where
-    getter buf =
-      fromMaybe def $ buf ^. bufExts . at (typeRep (Proxy :: Proxy a)) .
-      mapping coerce
-    setter buf new =
-      set
-        (bufExts . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
-        (Just new)
-        buf
-    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext
 
 -- | Creates a new buffer from the given text.
 mkBuffer :: Y.YiString -> Buffer

--- a/rasa/src/Rasa/Internal/Editor.hs
+++ b/rasa/src/Rasa/Internal/Editor.hs
@@ -13,8 +13,6 @@ module Rasa.Internal.Editor
   , HasEditor(..)
   , buffers
   , exiting
-  , ext
-  , bufExt
   , nextBufId
   , BufRef(..)
   ) where
@@ -22,10 +20,7 @@ module Rasa.Internal.Editor
 import Rasa.Internal.Buffer
 import Rasa.Internal.Extensions
 
-import Unsafe.Coerce
-import Data.Dynamic
 import Data.Default
-import Data.Maybe
 import Data.IntMap
 import Control.Lens
 
@@ -49,7 +44,7 @@ makeLenses ''Editor
 instance Show Editor where
   show ed =
     "Buffers==============\n" ++ show (ed^.buffers) ++ "\n\n"
-    ++ "Editor Extensions==============\n" ++ show (ed^.extState) ++ "\n\n"
+    ++ "Editor Extensions==============\n" ++ show (ed^.exts) ++ "\n\n"
     ++ "---\n\n"
 
 -- | This allows polymorphic lenses over anything that has access to an Editor context
@@ -64,16 +59,15 @@ buffers = editor.buffers'
 exiting :: HasEditor e => Lens' e Bool
 exiting = editor.exiting'
 
--- | A lens over the extension state of 'Editor' level extensions
-extState :: HasEditor e => Lens' e ExtMap
-extState = editor.extState'
-
 -- | A lens over the next buffer id to be allocated
 nextBufId :: HasEditor e => Lens' e Int
 nextBufId = editor.nextBufId'
 
 instance HasEditor Editor where
   editor = lens id (flip const)
+
+instance HasExts Editor where
+  exts = extState'
 
 instance Default Editor where
   def =
@@ -83,26 +77,3 @@ instance Default Editor where
     , _exiting'=False
     , _nextBufId'=0
     }
-
--- | 'ext' is a lens which will focus the extension state that matches the type
--- inferred as the focal point. It's a little bit of magic, if you treat the
--- focus as a member of your extension state it should just work out.
---
--- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
--- nothing has yet been stored.
-
-ext
-  :: forall a e.
-    (Show a, Typeable a, Default a, HasEditor e)
-  => Lens' e a
-ext = lens getter setter
-  where
-    getter ed =
-      fromMaybe def $ ed ^. extState . at (typeRep (Proxy :: Proxy a)) .
-      mapping coerce
-    setter ed new =
-      set
-        (extState . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
-        (Just new)
-        ed
-    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext

--- a/rasa/src/Rasa/Internal/Events.hs
+++ b/rasa/src/Rasa/Internal/Events.hs
@@ -1,5 +1,5 @@
 {-# language ExistentialQuantification #-}
-module Rasa.Internal.Events 
+module Rasa.Internal.Events
   ( Init(..)
   , BeforeEvent(..)
   , BeforeRender(..)
@@ -71,4 +71,4 @@ data Mod
 data BufTextChanged
   = BufTextChanged CrdRange Y.YiString
   deriving (Show, Eq, Typeable)
-  
+

--- a/rasa/src/Rasa/Internal/Extensions.hs
+++ b/rasa/src/Rasa/Internal/Extensions.hs
@@ -2,10 +2,19 @@
 module Rasa.Internal.Extensions
   ( Ext(..)
   , ExtMap
+  , HasBufExts(..)
+  , HasExts(..)
+  , bufExt
+  , ext
   ) where
 
+import Control.Lens
+
+import Data.Default
 import Data.Map
 import Data.Dynamic
+import Data.Maybe
+import Unsafe.Coerce
 
 -- | A wrapper around an extension of any type so it can be stored in an 'ExtMap'
 data Ext = forall a. Show a => Ext a
@@ -14,3 +23,60 @@ instance Show Ext where
 
 -- | A map of extension types to their current value.
 type ExtMap = Map TypeRep Ext
+
+class HasExts s where
+  -- | This lens focuses the Extensions States
+  exts :: Lens' s (Map TypeRep Ext)
+
+-- | 'ext' is a lens which will focus the extension state that matches the type
+-- inferred as the focal point. It's a little bit of magic, if you treat the
+-- focus as a member of your extension state it should just work out.
+--
+-- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
+-- nothing has yet been stored.
+
+ext
+  :: forall a e.
+    (Show a, Typeable a, Default a, HasExts e)
+  => Lens' e a
+ext = lens getter setter
+  where
+    getter s =
+      fromMaybe def $ s ^.exts . at (typeRep (Proxy :: Proxy a)) .
+      mapping coerce
+    setter s new =
+      set
+        (exts . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
+        (Just new)
+        s
+    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext
+
+class HasBufExts s where
+  -- | This lens focuses the Extensions States map of the in-scope buffer.
+  bufExts :: Lens' s (Map TypeRep Ext)
+
+-- | 'bufExt' is a lens which will focus a given extension's state within a
+-- buffer (within a 'Data.Action.BufAction'). The lens will automagically focus
+-- the required extension by using type inference. It's a little bit of magic,
+-- if you treat the focus as a member of your extension state it should just
+-- work out.
+--
+-- This lens falls back on the extension's 'Data.Default.Default' instance (when getting) if
+-- nothing has yet been stored.
+
+bufExt
+  :: forall a s.
+    (Show a, Typeable a, Default a, HasBufExts s)
+    => Lens' s a
+bufExt = lens getter setter
+  where
+    getter buf =
+      fromMaybe def $ buf ^. bufExts . at (typeRep (Proxy :: Proxy a)) .
+      mapping coerce
+    setter buf new =
+      set
+        (bufExts . at (typeRep (Proxy :: Proxy a)) . mapping coerce)
+        (Just new)
+        buf
+    coerce :: (Show a1) =>  Iso Ext Ext a a1
+    coerce = iso (\(Ext x) -> unsafeCoerce x) Ext

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -22,7 +22,6 @@ module Rasa.Internal.Range
   , range
   , rStart
   , rEnd
-  , getRange
   , sizeOf
   , sizeOfR
   , moveRange
@@ -36,7 +35,6 @@ module Rasa.Internal.Range
   , afterC
   ) where
 
-import Rasa.Internal.Buffer
 import Rasa.Internal.Text
 import Control.Lens
 
@@ -246,12 +244,7 @@ afterC c@(Coord row col) = lens getter setter
                           in prefix <> new
 
 -- | A lens over text which is encompassed by a 'Range'
-range :: HasBuffer s =>  CrdRange -> Lens' s Y.YiString
+range :: CrdRange -> Lens' Y.YiString Y.YiString
 range (Range start end) = lens getter setter
-  where getter = view (text . beforeC end . afterC start)
-        setter old new = old & text . beforeC end . afterC start .~ new
-
--- | A getter-lens over text which is encompassed by a 'Range'
-getRange :: HasBuffer s => CrdRange -> Getting r s Y.YiString
-getRange (Range start end) = to getter
-  where getter = view (text . beforeC end . afterC start)
+  where getter = view (beforeC end . afterC start)
+        setter old new = old & beforeC end . afterC start .~ new


### PR DESCRIPTION
For those who are unfamiliar with [`free`](http://hackage.haskell.org/package/free-2.0.3), it's basically a version of a monad which only 'Keeps Track' of the things you'd like to do rather than actually executing them. Even `IO`s are just stored in a wrapper without being executed. Then once the actions are all sequenced you run them through an 'interpreter' which actually does things based on a mapping from the Action Descriptions to actual functionality.

Re-writing in terms of Free adds a little boilerplate; but gives us much more expressability and power. It allows us to log out ever message we perform; it allows us to "mock out" results from IO calls, and makes testing much simpler.

It is a little more confusing; so if you have questions please ask; but I definitely believe that it's in Rasa's best interests in the long run!