### PR TITLE
Use Pipes for async event and Action dispatch

### DIFF
--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
@@ -1,8 +1,9 @@
 module Rasa.Ext.Slate.Internal.Event (terminalEvents) where
 
 import Rasa.Ext
-
 import Rasa.Ext.Slate.Internal.State
+
+import Control.Monad
 
 import qualified Graphics.Vty as V
 
@@ -10,7 +11,9 @@ import qualified Graphics.Vty as V
 terminalEvents :: Action ()
 terminalEvents = do
     v <- getVty
-    eventProvider $ convertEvent <$> V.nextEvent v
+    asyncEventProvider $ getEvents v
+      where
+        getEvents v dispatch = forever $ V.nextEvent v >>= dispatch . convertEvent
 
 -- | Converts a 'V.Event' into a keypress if possible.
 convertEvent :: V.Event -> Keypress

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -80,6 +80,9 @@ library
                      , text-lens
                      , transformers
                      , yi-rope
+                     , pipes
+                     , pipes-concurrency
+                     , pipes-parse
 
   default-language:    Haskell2010
 

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -6,12 +6,14 @@ import Rasa.Internal.Action
 import Rasa.Internal.Events
 import Rasa.Internal.Scheduler
 
-import Control.Concurrent.Async
 import Control.Lens
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.Default (def)
-import Data.List
+import Data.Maybe
+
+import Pipes
+import Pipes.Concurrent
+import Pipes.Parse
 
 -- | The main function to run rasa.
 --
@@ -26,25 +28,24 @@ import Data.List
 -- >   slate
 
 rasa :: Action () -> IO ()
-rasa initilize =
-  evalAction def $ do
+rasa initilize = do
+  (output, input) <- spawn unbounded
+  evalAction (mkActionState output) $ do
     initilize
     dispatchEvent Init
-    eventLoop
+    eventLoop $ fromInput input
     dispatchEvent Exit
 
 -- | This is the main event loop, it runs recursively forever until something
 -- sets 'Rasa.Editor.exiting'. It runs the pre-event hooks, then checks if any
 -- async events have finished, then runs the post event hooks and repeats.
-eventLoop :: Action ()
-eventLoop = do
+eventLoop :: Producer (Action ()) IO () -> Action ()
+eventLoop producer = do
   dispatchEvent BeforeRender
   dispatchEvent OnRender
   dispatchEvent AfterRender
   dispatchEvent BeforeEvent
-  asyncActions <- use asyncs
-  (done, action) <- liftIO $ waitAny asyncActions
-  asyncs %= delete done
-  action
+  (mAction, nextProducer) <- liftIO $ runStateT draw producer
+  fromMaybe (return ()) mAction
   isExiting <- use exiting
-  unless isExiting eventLoop
+  unless isExiting $ eventLoop nextProducer

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -40,7 +40,6 @@ module Rasa.Ext
   (
   -- * Editor Actions
     Action
-  , doAsync
   , exit
 
   -- * Managing Buffers
@@ -125,7 +124,6 @@ module Rasa.Ext
   , onEveryTrigger_
   , onNextEvent
   , removeListener
-  , eventProvider
 
   -- * Built-in Event Hooks
   , onInit
@@ -144,6 +142,12 @@ module Rasa.Ext
   , onExit
   , onBufAdded
   , onBufTextChanged
+
+  -- * Working with Async Events/Actions
+  , dispatchActionAsync
+  , dispatchEventAsync
+  , asyncEventProvider
+  , asyncActionProvider
 
    -- * Ranges
   , Range(..)

--- a/rasa/src/Rasa/Internal/Async.hs
+++ b/rasa/src/Rasa/Internal/Async.hs
@@ -1,31 +1,72 @@
-module Rasa.Internal.Async 
-  ( doAsync
-  , eventProvider
+module Rasa.Internal.Async
+  ( asyncEventProvider
+  , asyncActionProvider
+  , dispatchEventAsync
+  , dispatchActionAsync
 ) where
 
 import Rasa.Internal.Action
 import Rasa.Internal.Scheduler
 
-import Data.Typeable
-import Control.Concurrent.Async
 import Control.Lens
 import Control.Monad.IO.Class
 
+import Data.Typeable
+
+import Pipes
+import Pipes.Concurrent
+
+-- | A helper which when given an output channel results in a function from @Action () -> IO ()@ which
+-- dispatches any actions it's called with asyncronously to the main event loop.
+dispatchAction :: Output (Action ()) -> Action () -> IO ()
+dispatchAction output act =
+   void . forkIO $ do runEffect $ yield act >-> toOutput output
+                      performGC
+
 -- | This function takes an IO which results in some Event, it runs the IO
--- asynchronously and dispatches the event, then repeats the process all over
--- again. Use this inside the onInit scheduler to register an event listener
--- for some event (e.g. keypresses or network activity)
+-- asynchronously and dispatches the event
+dispatchEventAsync :: Typeable a => IO a -> Action ()
+dispatchEventAsync getEventIO = do
+  out <- use actionQueue
+  liftIO $ void . forkIO $ do runEffect $ producer >-> toOutput out
+                              performGC
+  where
+    producer :: Producer (Action ()) IO ()
+    producer = do
+          evt <- lift getEventIO
+          yield (dispatchEvent evt)
 
-eventProvider :: Typeable a => IO a -> Action ()
-eventProvider getEventIO = doAsync (dispatchAndRerun <$> getEventIO)
-    where dispatchAndRerun evt = do
-            dispatchEvent evt
-            eventProvider getEventIO
+-- | Don't let the type signature confuse you; it's much simpler than it seems.
+-- The first argument is a function which takes an event provider; the event provider
+-- will be passed a dispatch function which can be called as often as you like with Events of any 'Typeable' type.
+-- (see the "Rasa.Internal.Events")
+-- When it is passed an 'Action' it forks off an IO to dispatch that 'Action' to the main event loop.
+-- Note that the dispatch function calls forkIO on its own; so there's no need for you to do so.
+--
+-- Use this function when you have some long-running process which dispatches multiple 'Action's.
 
--- | doAsync allows you to perform a task asynchronously and then apply the
--- result. In @doAsync asyncAction@, @asyncAction@ is an IO which resolves to
+asyncEventProvider :: Typeable a => ((a -> IO ()) -> IO ()) -> Action ()
+asyncEventProvider eventProvidingIO = do
+  out <- use actionQueue
+  liftIO $ void . forkIO $ eventProvidingIO (dispatchAction out . dispatchEvent)
+
+-- | Don't let the type signature confuse you; it's much simpler than it seems.
+-- The first argument is a function which takes an action provider; the action provider
+-- will be passed a dispatch function which can be called as often as you like with @Action ()@s.
+-- When it is passed an 'Action' it forks off an IO to dispatch that 'Action' to the main event loop.
+-- Note that the dispatch function calls forkIO on its own; so there's no need for you to do so.
+--
+-- Use this function when you have some long-running process which dispatches multiple 'Action's.
+
+asyncActionProvider :: ((Action () -> IO ()) -> IO ()) -> Action ()
+asyncActionProvider actionProvidingIO = do
+  out <- use actionQueue
+  liftIO $ void . forkIO $ actionProvidingIO (dispatchAction out)
+
+-- | dispatchActionAsync allows you to perform a task asynchronously and then apply the
+-- result. In @dispatchActionAsync asyncAction@, @asyncAction@ is an IO which resolves to
 -- an Action, note that the context in which the second action is executed is
--- NOT the same context in which doAsync is called; it is likely that text and
+-- NOT the same context in which dispatchActionAsync is called; it is likely that text and
 -- other state have changed while the IO executed, so it's a good idea to check
 -- (inside the applying Action) that things are in a good state before making
 -- changes. Here's an example:
@@ -33,8 +74,8 @@ eventProvider getEventIO = doAsync (dispatchAndRerun <$> getEventIO)
 -- > asyncCapitalize :: Action ()
 -- > asyncCapitalize = do
 -- >   txt <- focusDo $ use text
--- >   -- We give doAsync an IO which resolves in an action
--- >   doAsync $ ioPart txt
+-- >   -- We give dispatchActionAsync an IO which resolves in an action
+-- >   dispatchActionAsync $ ioPart txt
 -- >
 -- > ioPart :: Text -> IO (Action ())
 -- > ioPart txt = do
@@ -53,7 +94,11 @@ eventProvider getEventIO = doAsync (dispatchAndRerun <$> getEventIO)
 -- >     -- Or we could just give up.
 -- >     else asyncCapitalize
 
-doAsync ::  IO (Action ()) -> Action ()
-doAsync asyncIO = do
-  newAsync <- liftIO $ async asyncIO
-  asyncs <>= [newAsync]
+dispatchActionAsync ::  IO (Action ()) -> Action ()
+dispatchActionAsync asyncIO = do
+  queue <- use actionQueue
+  liftIO $ void $ forkIO $ do runEffect $ producer >-> toOutput queue
+                              performGC
+  where producer = do
+          action <- lift asyncIO
+          yield action

--- a/rasa/src/Rasa/Internal/Events.hs
+++ b/rasa/src/Rasa/Internal/Events.hs
@@ -17,11 +17,6 @@ import Rasa.Internal.Editor
 import Rasa.Internal.Range
 import qualified Yi.Rope as Y
 
--- | The Event type represents a common denominator for all actions that could
--- occur Event transmitters express events that have occured as a member of this
--- type. At the moment it's quite sparse, but it will expand as new types of
--- events are needed.
-
 -- | This event is dispatched exactly once when the editor starts up.
 data Init = Init deriving (Show, Eq, Typeable)
 
@@ -68,6 +63,8 @@ data Mod
   | Shift
   deriving (Show, Eq)
 
+-- | This is triggered when text in a buffer is changed. The Event data includes the 'CrdRange' that changed and
+-- the new text which is now contined in that range.
 data BufTextChanged
   = BufTextChanged CrdRange Y.YiString
   deriving (Show, Eq, Typeable)


### PR DESCRIPTION
Refactors event system to use Pipes and Pipes.Parse; this lets us cleanly allow dispatching events asynchronously to mailboxes which provide for the main event loop. This is convenient when running persistent actions which may yield several events; for example listening for network traffic or running expensive parsers, or listening for file-system events.

Adds the following utilities:
```haskell
asyncEventProvider :: Typeable a => ((a -> IO ()) -> IO ()) -> Action ()
asyncActionProvider :: ((Action () -> IO ()) -> IO ()) -> Action ()
dispatchActionAsync ::  IO (Action ()) -> Action ()
dispatchEventAsync :: Typeable a => IO a -> Action ()
```
