### PR TITLE
Generalize trigger function types to abstract void Actions

### DIFF
--- a/docs/Building-An-Extension.md
+++ b/docs/Building-An-Extension.md
@@ -128,21 +128,22 @@ Hrmm, right! Now that we're listening for keypress events we don't want to use
 at the type signature:
 
 ```haskell
-onEveryTrigger :: forall a. Typeable a => (a -> Action ()) -> Action HookId
+onEveryTrigger :: forall a b. Typeable a => (a -> Action b) -> Action HookId
 ```
 
 Whoah, what?? It's tough to unpack exactly what's going on here, but the basic
-idea is that you can see it takes a function from ANY (Typeable) event `a` to an `Action
-()` and then returns another `Action ()` that will respond to events.  There's
-a bit of magic behind the scenes that stores the function and calls it on any
-events that come that match the type which that function expects, running the
-resulting Action.  Check out the source code behind `onEveryTrigger` if
-you're interested!  It's pretty cool!  But for now we'll just move on and trust
-that it does what it says. So we've got our function from our event type
-(Keypress), so let's try embedding it using `onEveryTrigger`; the function normally
-returns a reference to the newly created listener so that we could cancel the listener
-using `removeListener` later if we wanted to; but since we don't want to do that we'll
-use `onEveryTrigger_` which just discards it instead.
+idea is that you can see it takes a function from ANY (Typeable) event `a` to
+any `Action b` and then returns an `Action ()` that will respond to events.
+There's a bit of magic behind the scenes that stores the function and calls it
+on any events that come that match the type which that function expects,
+running the resulting Action.  Check out the source code behind
+`onEveryTrigger` if you're interested!  It's pretty cool!  But for now we'll
+just move on and trust that it does what it says. So we've got our function
+from our event type (Keypress), so let's try embedding it using
+`onEveryTrigger`; the function normally returns a reference to the newly
+created listener so that we could cancel the listener using `removeListener`
+later if we wanted to; but since we don't want to do that we'll use
+`onEveryTrigger_` which just discards it instead.
 
 ```haskell
 main = rasa $ do

--- a/docs/Building-An-Extension.md
+++ b/docs/Building-An-Extension.md
@@ -62,7 +62,7 @@ main :: IO ()
 main = rasa $ do
   -- some plugins...
   -- Add the new action here!
-  void $ onInit helloWorld
+  onInit helloWorld
 ```
 
 Okay let's try again! `stack build && stack exec rasa` (you may want to alias

--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -29,4 +29,4 @@ main = rasa $ do
   logger
   slate
   style
-  onInit . void $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"
+  onInit $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"

--- a/rasa/src/Rasa/Internal/Scheduler.hs
+++ b/rasa/src/Rasa/Internal/Scheduler.hs
@@ -81,11 +81,10 @@ onEveryTrigger hookFunc = do
 onEveryTrigger_ :: forall a. Typeable a => (a -> Action ()) -> Action ()
 onEveryTrigger_ = void . onEveryTrigger
 
-
 -- | This acts as 'onEveryTrigger' but listens only for the first event of a given type.
-onNextEvent :: forall a. Typeable a => (a -> Action ()) -> Action ()
+onNextEvent :: forall a b. Typeable a => (a -> Action b) -> Action ()
 onNextEvent hookFunc = do
-  (hookId, hook) <- makeHook hookFunc
+  (hookId, hook) <- makeHook $ void . hookFunc
   let selfCancellingHook = extendHook hook (removeListener hookId)
   hooks %= insertWith mappend (typeRep (Proxy :: Proxy a)) [selfCancellingHook]
 
@@ -102,8 +101,8 @@ removeListener hkIdA@(HookId _ typ) =
 -- Though arbitrary actions may be performed in the configuration block;
 -- it's recommended to embed such actions in the onInit event listener
 -- so that all event listeners are registered before anything Actions occur.
-onInit :: Action () -> Action ()
-onInit action = void $ onEveryTrigger (const action :: Init -> Action ())
+onInit :: forall a. Action a -> Action ()
+onInit action = onNextEvent (const action :: Init -> Action a)
 
 -- | Registers an action to be performed BEFORE each event phase.
 beforeEveryEvent :: Action () -> Action HookId
@@ -112,8 +111,8 @@ beforeEveryEvent action = onEveryTrigger (const action :: BeforeEvent -> Action 
 beforeEveryEvent_ :: Action () -> Action ()
 beforeEveryEvent_ = void . beforeEveryEvent
 
-beforeNextEvent :: Action () -> Action ()
-beforeNextEvent action = onNextEvent (const action :: BeforeEvent -> Action ())
+beforeNextEvent :: forall a. Action a -> Action ()
+beforeNextEvent action = onNextEvent (const action :: BeforeEvent -> Action a)
 
 -- | Registers an action to be performed BEFORE each render phase.
 --
@@ -126,8 +125,8 @@ beforeEveryRender action = onEveryTrigger (const action :: BeforeRender -> Actio
 beforeEveryRender_ :: Action () -> Action ()
 beforeEveryRender_ = void . beforeEveryRender
 
-beforeNextRender :: Action () -> Action ()
-beforeNextRender action = onNextEvent (const action :: BeforeRender -> Action ())
+beforeNextRender :: forall a. Action a -> Action ()
+beforeNextRender action = onNextEvent (const action :: BeforeRender -> Action a)
 
 -- | Registers an action to be performed during each render phase.
 --
@@ -138,8 +137,8 @@ onEveryRender action = onEveryTrigger (const action :: OnRender -> Action ())
 onEveryRender_ :: Action () -> Action ()
 onEveryRender_ = void . onEveryRender
 
-onNextRender :: Action () -> Action ()
-onNextRender action = onNextEvent (const action :: OnRender -> Action ())
+onNextRender :: forall a. Action a -> Action ()
+onNextRender action = onNextEvent (const action :: OnRender -> Action a)
 
 -- | Registers an action to be performed AFTER each render phase.
 --
@@ -151,8 +150,8 @@ afterEveryRender action = onEveryTrigger (const action :: AfterRender -> Action 
 afterEveryRender_ :: Action () -> Action ()
 afterEveryRender_ = void . afterEveryRender
 
-afterNextRender :: Action () -> Action ()
-afterNextRender action = onNextEvent (const action :: AfterRender -> Action ())
+afterNextRender :: forall a. Action a -> Action ()
+afterNextRender action = onNextEvent (const action :: AfterRender -> Action a)
 
 -- | Registers an action to be performed during the exit phase.
 --
@@ -160,8 +159,8 @@ afterNextRender action = onNextEvent (const action :: AfterRender -> Action ())
 -- allows an opportunity to do clean-up, kill any processes you've started, or
 -- save any data before the editor terminates.
 
-onExit :: Action () -> Action ()
-onExit action = void $ onEveryTrigger (const action :: Exit -> Action ())
+onExit :: forall a. Action a -> Action ()
+onExit action = onNextEvent (const action :: Exit -> Action a)
 
 -- | Registers an action to be performed after a new buffer is added.
 --

--- a/rasa/src/Rasa/Internal/Scheduler.hs
+++ b/rasa/src/Rasa/Internal/Scheduler.hs
@@ -55,11 +55,12 @@ getHook = coerce
     coerce :: Hook -> (a -> Action ())
     coerce (Hook _ x) = unsafeCoerce x
 
-makeHook :: forall a. Typeable a => (a -> Action ()) -> Action (HookId, Hook)
+makeHook :: forall a b. Typeable a => (a -> Action b) -> Action (HookId, Hook)
 makeHook hookFunc = do
   n <- nextHook <<+= 1
   let hookId = HookId n (typeRep (Proxy :: Proxy a))
-  return (hookId, Hook hookId hookFunc)
+      hookFunc' = void . hookFunc
+  return (hookId, Hook hookId hookFunc')
 
 extendHook :: Hook -> Action () -> Hook
 extendHook (Hook hookId hookFunc) act = Hook hookId (\a -> hookFunc a >> act)
@@ -72,19 +73,19 @@ matchingHooks hooks' = getHook <$> (hooks'^.at (typeRep (Proxy :: Proxy a))._Jus
 --
 -- @MyEventType -> Action ()@ then it will be triggered on all dispatched events of that type.
 -- It returns an ID which may be used with 'removeListener' to cancel the listener
-onEveryTrigger :: forall a. Typeable a => (a -> Action ()) -> Action HookId
+onEveryTrigger :: forall a b. Typeable a => (a -> Action b) -> Action HookId
 onEveryTrigger hookFunc = do
   (hookId, hook) <- makeHook hookFunc
   hooks %= insertWith mappend (typeRep (Proxy :: Proxy a)) [hook]
   return hookId
 
-onEveryTrigger_ :: forall a. Typeable a => (a -> Action ()) -> Action ()
+onEveryTrigger_ :: forall a b. Typeable a => (a -> Action b) -> Action ()
 onEveryTrigger_ = void . onEveryTrigger
 
 -- | This acts as 'onEveryTrigger' but listens only for the first event of a given type.
 onNextEvent :: forall a b. Typeable a => (a -> Action b) -> Action ()
 onNextEvent hookFunc = do
-  (hookId, hook) <- makeHook $ void . hookFunc
+  (hookId, hook) <- makeHook hookFunc
   let selfCancellingHook = extendHook hook (removeListener hookId)
   hooks %= insertWith mappend (typeRep (Proxy :: Proxy a)) [selfCancellingHook]
 
@@ -105,10 +106,10 @@ onInit :: forall a. Action a -> Action ()
 onInit action = onNextEvent (const action :: Init -> Action a)
 
 -- | Registers an action to be performed BEFORE each event phase.
-beforeEveryEvent :: Action () -> Action HookId
-beforeEveryEvent action = onEveryTrigger (const action :: BeforeEvent -> Action ())
+beforeEveryEvent :: forall a. Action a -> Action HookId
+beforeEveryEvent action = onEveryTrigger (const action :: BeforeEvent -> Action a)
 
-beforeEveryEvent_ :: Action () -> Action ()
+beforeEveryEvent_ :: forall a. Action a -> Action ()
 beforeEveryEvent_ = void . beforeEveryEvent
 
 beforeNextEvent :: forall a. Action a -> Action ()
@@ -119,10 +120,10 @@ beforeNextEvent action = onNextEvent (const action :: BeforeEvent -> Action a)
 -- This is a good spot to add information useful to the renderer
 -- since all actions have been performed. Only cosmetic changes should
 -- occur during this phase.
-beforeEveryRender :: Action () -> Action HookId
-beforeEveryRender action = onEveryTrigger (const action :: BeforeRender -> Action ())
+beforeEveryRender :: forall a. Action a -> Action HookId
+beforeEveryRender action = onEveryTrigger (const action :: BeforeRender -> Action a)
 
-beforeEveryRender_ :: Action () -> Action ()
+beforeEveryRender_ :: forall a. Action a -> Action ()
 beforeEveryRender_ = void . beforeEveryRender
 
 beforeNextRender :: forall a. Action a -> Action ()
@@ -131,10 +132,10 @@ beforeNextRender action = onNextEvent (const action :: BeforeRender -> Action a)
 -- | Registers an action to be performed during each render phase.
 --
 -- This phase should only be used by extensions which actually render something.
-onEveryRender :: Action () -> Action HookId
-onEveryRender action = onEveryTrigger (const action :: OnRender -> Action ())
+onEveryRender :: forall a. Action a -> Action HookId
+onEveryRender action = onEveryTrigger (const action :: OnRender -> Action a)
 
-onEveryRender_ :: Action () -> Action ()
+onEveryRender_ :: forall a. Action a -> Action ()
 onEveryRender_ = void . onEveryRender
 
 onNextRender :: forall a. Action a -> Action ()
@@ -144,10 +145,10 @@ onNextRender action = onNextEvent (const action :: OnRender -> Action a)
 --
 -- This is useful for cleaning up extension state that was registered for the
 -- renderer, but needs to be cleared before the next iteration.
-afterEveryRender :: Action () -> Action HookId
-afterEveryRender action = onEveryTrigger (const action :: AfterRender -> Action ())
+afterEveryRender :: forall a. Action a -> Action HookId
+afterEveryRender action = onEveryTrigger (const action :: AfterRender -> Action a)
 
-afterEveryRender_ :: Action () -> Action ()
+afterEveryRender_ :: forall a. Action a -> Action ()
 afterEveryRender_ = void . afterEveryRender
 
 afterNextRender :: forall a. Action a -> Action ()
@@ -165,12 +166,12 @@ onExit action = onNextEvent (const action :: Exit -> Action a)
 -- | Registers an action to be performed after a new buffer is added.
 --
 -- The supplied function will be called with a 'BufRef' to the new buffer, and the resulting 'Action' will be run.
-onBufAdded :: (BufRef -> Action ()) -> Action HookId
+onBufAdded :: forall a. (BufRef -> Action a) -> Action HookId
 onBufAdded f = onEveryTrigger listener
   where
     listener (BufAdded bRef) = f bRef
 
-onBufTextChanged :: (CrdRange -> Y.YiString -> Action ()) -> Action HookId
+onBufTextChanged :: forall a. (CrdRange -> Y.YiString -> Action a) -> Action HookId
 onBufTextChanged f = onEveryTrigger listener
   where
     listener (BufTextChanged r newText) = f r newText


### PR DESCRIPTION
We can call void while making the hook so that we don't need to remember to do it everywhere else.