### PR TITLE
Mod support for all Keypress.

### DIFF
--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
@@ -22,13 +22,13 @@ convertEvent _ = KUnknown
 
 -- | Converts a 'V.Event' into a keypress if possible.
 convertKeypress :: V.Key -> [V.Modifier] -> Keypress
-convertKeypress V.KEnter _ = KEnter
-convertKeypress V.KBS _ = KBS
-convertKeypress V.KEsc _ = KEsc
-convertKeypress V.KLeft _ = KLeft
-convertKeypress V.KRight _ = KRight
-convertKeypress V.KUp _ = KUp
-convertKeypress V.KDown _ = KDown
+convertKeypress V.KEnter mods     = KEnter (fmap convertMod mods)
+convertKeypress V.KBS mods        = KBS (fmap convertMod mods)
+convertKeypress V.KEsc mods       = KEsc (fmap convertMod mods)
+convertKeypress V.KLeft mods      = KLeft (fmap convertMod mods)
+convertKeypress V.KRight mods     = KRight (fmap convertMod mods)
+convertKeypress V.KUp mods        = KUp (fmap convertMod mods)
+convertKeypress V.KDown mods      = KDown (fmap convertMod mods)
 convertKeypress (V.KChar c) mods  = Keypress c (fmap convertMod mods)
 convertKeypress _ _ = KUnknown
 

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
@@ -22,14 +22,20 @@ convertEvent _ = KUnknown
 
 -- | Converts a 'V.Event' into a keypress if possible.
 convertKeypress :: V.Key -> [V.Modifier] -> Keypress
-convertKeypress V.KEnter mods     = KEnter (fmap convertMod mods)
-convertKeypress V.KBS mods        = KBS (fmap convertMod mods)
-convertKeypress V.KEsc mods       = KEsc (fmap convertMod mods)
-convertKeypress V.KLeft mods      = KLeft (fmap convertMod mods)
-convertKeypress V.KRight mods     = KRight (fmap convertMod mods)
-convertKeypress V.KUp mods        = KUp (fmap convertMod mods)
-convertKeypress V.KDown mods      = KDown (fmap convertMod mods)
-convertKeypress (V.KChar c) mods  = Keypress c (fmap convertMod mods)
+convertKeypress V.KEsc mods      = KEsc (fmap convertMod mods)
+convertKeypress (V.KChar c) mods = Keypress c (fmap convertMod mods)
+convertKeypress V.KBS mods       = KBS (fmap convertMod mods)
+convertKeypress V.KEnter mods    = KEnter (fmap convertMod mods)
+convertKeypress V.KLeft mods     = KLeft (fmap convertMod mods)
+convertKeypress V.KRight mods    = KRight (fmap convertMod mods)
+convertKeypress V.KUp mods       = KUp (fmap convertMod mods)
+convertKeypress V.KDown mods     = KDown (fmap convertMod mods)
+convertKeypress V.KPrtScr mods   = KPrtScr (fmap convertMod mods)
+convertKeypress V.KHome mods     = KHome (fmap convertMod mods)
+convertKeypress V.KPageUp mods   = KPageUp (fmap convertMod mods)
+convertKeypress V.KDel mods      = KDel (fmap convertMod mods)
+convertKeypress V.KEnd mods      = KEnd (fmap convertMod mods)
+convertKeypress V.KPageDown mods = KPageDown (fmap convertMod mods)
 convertKeypress _ _ = KUnknown
 
 -- | Converts a 'V.Modifier' into a 'Mod'.
@@ -37,5 +43,5 @@ convertMod :: V.Modifier -> Mod
 convertMod m = case m of
                  V.MShift -> Shift
                  V.MCtrl -> Ctrl
-                 V.MMeta -> Alt
+                 V.MMeta -> Meta
                  V.MAlt -> Alt

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -79,15 +79,20 @@ setStatus = focusDo_ $ do
 -- | Listeners for keypresses that run regardless of current mode.
 anyMode :: [Keypress] -> BufAction ()
 anyMode [Keypress 'c' [Ctrl]] = liftAction exit
+anyMode [KPageDown []] = liftAction $ scrollBy 14 -- Page down
+anyMode [KPageUp []] = liftAction $ scrollBy (-14) -- Page up
+anyMode [KHome []] = startOfLine
+anyMode [KEnd []] = endOfLine
 anyMode _ = return ()
 
 -- | Listeners for keypresses when in 'Insert' mode
 insert :: [Keypress] -> BufAction ()
-insert [KEsc _] = mode .= Normal
+insert [KEsc []] = mode .= Normal
 
-insert [KBS _] = moveRangesByN (-1) >> delete
-insert [KEnter _] = insertText "\n" >> moveRangesByC (Coord 1 0) >> startOfLine
-insert [Keypress c _] = insertText (Y.singleton c) >> moveRangesByN 1
+insert [KBS []] = moveRangesByN (-1) >> delete
+insert [KDel []] = delete
+insert [KEnter []] = insertText "\n" >> moveRangesByC (Coord 1 0) >> startOfLine
+insert [Keypress c []] = insertText (Y.singleton c) >> moveRangesByN 1
 insert _ = return ()
 
 -- | Listeners for keypresses when in 'Normal' mode
@@ -113,10 +118,10 @@ normal [Keypress 'd' [Ctrl]] = liftAction $ scrollBy 7 -- Half-Page down
 normal [Keypress 'y' [Ctrl]] = liftAction $ scrollBy (-1) -- Scroll up
 normal [Keypress 'u' [Ctrl]] = liftAction $ scrollBy (-7) -- Half-Page up
 
-normal [KLeft _] = liftAction focusViewLeft
-normal [KRight _] = liftAction focusViewRight
-normal [KUp _] = liftAction focusViewAbove
-normal [KDown _] = liftAction focusViewBelow
+normal [KLeft []] = liftAction focusViewLeft
+normal [KRight []] = liftAction focusViewRight
+normal [KUp []] = liftAction focusViewAbove
+normal [KDown []] = liftAction focusViewBelow
 
 
 normal [Keypress 'G' []] = do

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -83,10 +83,10 @@ anyMode _ = return ()
 
 -- | Listeners for keypresses when in 'Insert' mode
 insert :: [Keypress] -> BufAction ()
-insert [KEsc] = mode .= Normal
+insert [KEsc _] = mode .= Normal
 
-insert [KBS] = moveRangesByN (-1) >> delete
-insert [KEnter] = insertText "\n" >> moveRangesByC (Coord 1 0) >> startOfLine
+insert [KBS _] = moveRangesByN (-1) >> delete
+insert [KEnter _] = insertText "\n" >> moveRangesByC (Coord 1 0) >> startOfLine
 insert [Keypress c _] = insertText (Y.singleton c) >> moveRangesByN 1
 insert _ = return ()
 
@@ -113,10 +113,10 @@ normal [Keypress 'd' [Ctrl]] = liftAction $ scrollBy 7 -- Half-Page down
 normal [Keypress 'y' [Ctrl]] = liftAction $ scrollBy (-1) -- Scroll up
 normal [Keypress 'u' [Ctrl]] = liftAction $ scrollBy (-7) -- Half-Page up
 
-normal [KLeft] = liftAction focusViewLeft
-normal [KRight] = liftAction focusViewRight
-normal [KUp] = liftAction focusViewAbove
-normal [KDown] = liftAction focusViewBelow
+normal [KLeft _] = liftAction focusViewLeft
+normal [KRight _] = liftAction focusViewRight
+normal [KUp _] = liftAction focusViewAbove
+normal [KDown _] = liftAction focusViewBelow
 
 
 normal [Keypress 'G' []] = do
@@ -161,7 +161,7 @@ normal [Keypress 'X' []] = moveRangesByN (-1) >> delete
 normal [Keypress 'x' []] = delete
 normal [Keypress 's' [Ctrl]] = save
 normal [Keypress ';' []] = do
-  rngs <- getRanges 
+  rngs <- getRanges
   setRanges (rngs^.reversed.to (take 1))
 normal _ = return ()
 

--- a/rasa/src/Rasa/Internal/Events.hs
+++ b/rasa/src/Rasa/Internal/Events.hs
@@ -44,16 +44,15 @@ data BufAdded = BufAdded BufRef deriving (Show, Eq, Typeable)
 -- | This event is dispatched in response to keyboard key presses. It contains both
 -- the char that was pressed and any modifiers ('Mod') that where held when the key was pressed.
 data Keypress
-  = Keypress Char
-             [Mod]
-  | KEsc
-  | KBS
-  | KEnter
+  = Keypress Char [Mod]
+  | KEsc     [Mod]
+  | KBS      [Mod]
+  | KEnter   [Mod]
+  | KLeft    [Mod]
+  | KRight   [Mod]
+  | KUp      [Mod]
+  | KDown    [Mod]
   | KUnknown
-  | KLeft
-  | KRight
-  | KUp
-  | KDown
   deriving (Show, Eq, Typeable)
 
 -- | This represents each modifier key that could be pressed along with a key.
@@ -68,4 +67,3 @@ data Mod
 data BufTextChanged
   = BufTextChanged CrdRange Y.YiString
   deriving (Show, Eq, Typeable)
-

--- a/rasa/src/Rasa/Internal/Events.hs
+++ b/rasa/src/Rasa/Internal/Events.hs
@@ -45,13 +45,19 @@ data BufAdded = BufAdded BufRef deriving (Show, Eq, Typeable)
 -- the char that was pressed and any modifiers ('Mod') that where held when the key was pressed.
 data Keypress
   = Keypress Char [Mod]
-  | KEsc     [Mod]
-  | KBS      [Mod]
-  | KEnter   [Mod]
-  | KLeft    [Mod]
-  | KRight   [Mod]
-  | KUp      [Mod]
-  | KDown    [Mod]
+  | KEsc      [Mod]
+  | KBS       [Mod]
+  | KEnter    [Mod]
+  | KLeft     [Mod]
+  | KRight    [Mod]
+  | KUp       [Mod]
+  | KDown     [Mod]
+  | KPrtScr   [Mod]
+  | KHome     [Mod]
+  | KPageUp   [Mod]
+  | KDel      [Mod]
+  | KEnd      [Mod]
+  | KPageDown [Mod]
   | KUnknown
   deriving (Show, Eq, Typeable)
 
@@ -60,6 +66,7 @@ data Mod
   = Ctrl
   | Alt
   | Shift
+  | Meta
   deriving (Show, Eq)
 
 -- | This is triggered when text in a buffer is changed. The Event data includes the 'CrdRange' that changed and


### PR DESCRIPTION
Changes:
- Keypress to allow mods for every type except unknown
- Changes to slate to convert them
- Changes to Vim to ignore mods on keybindings that did not have mods before

Will look into adding things from Vty tomorrow.