### PR TITLE
Add nix-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,48 +34,6 @@ What people are saying
 
 > You should go outside one of these days. - Mother
 
-Installation
-------------
-
-At the moment you must build Rasa from source;
-
-1. Install [stack](http://seanhess.github.io/2015/08/04/practical-haskell-getting-started.html)
-2. Clone this repo and `cd` into the directory
-3. Run `stack build && stack exec rasa` (you may want to alias this to `rasa`)
-
-### Troubleshooting
-
-- You may need to install icu4c (`brew install icu4c`), it's a dependency of the rope library rasa uses. 
-- On linux, when the error message `Missing C libraries: icuuc, icui18n, icudata` appears, install `libicu-dev` (e.g. with `sudo apt install libicu-dev`).
-- You'll need to point to the icu4c lib in your stack.yaml wherever it's stored on your system. If you install
-    using brew on your Mac, then you can add the following to your stack.yaml:
-
-```yaml
-extra-lib-dirs:
-- /usr/local/opt/icu4c/lib 
-extra-include-dirs:
-- /usr/local/opt/icu4c/include
-```
-
-- Depending on which LTS you're on, you'll likely also have to add each rasa package you use to your stack.yaml as
-    extra-deps, here's an example:
-
-```yaml
-# in stack.yaml
-extra-deps:
-- rasa-0.1.0.0
-- rasa-ext-cursors-0.1.0.0
-- rasa-ext-logger-0.1.0.0
-- rasa-ext-status-bar-0.1.0.0
-- rasa-ext-vim-0.1.0.0
-- text-lens-0.1.0.0
-- rasa-ext-files-0.1.0.0
-- rasa-ext-cmd-0.1.0.0
-- rasa-ext-slate-0.1.0.0
-- rasa-ext-style-0.1.0.0
-- vty-5.14
-```
-
 Getting started
 ---------------
 
@@ -174,11 +132,59 @@ Run only tests for core editor:
 
 - `stack test rasa`
 
+
+Installation
+------------
+
+At the moment you must build Rasa from source;
+
+To provide reproducible builds, Rasa uses Stack & Nix.
+
+1. Install [stack](http://seanhess.github.io/2015/08/04/practical-haskell-getting-started.html)
+2. Install [nix](https://nixos.org/nix/)
+3. Clone this repo and `cd` into the directory
+4. Run `stack build && stack exec rasa` (you may want to alias this to `rasa`)
+
+### Troubleshooting
+
+- You may need to install icu4c (`brew install icu4c`), it's a dependency of the rope library rasa uses.
+- On linux, when the error message `Missing C libraries: icuuc, icui18n, icudata` appears, install `libicu-dev` (e.g. with `sudo apt install libicu-dev`).
+- You'll need to point to the icu4c lib in your stack.yaml wherever it's stored on your system. If you install
+    using brew on your Mac, then you can add the following to your stack.yaml:
+
+```yaml
+extra-lib-dirs:
+- /usr/local/opt/icu4c/lib 
+extra-include-dirs:
+- /usr/local/opt/icu4c/include
+```
+
+- Depending on which LTS you're on, you'll likely also have to add each rasa package you use to your stack.yaml as
+    extra-deps, here's an example:
+
+```yaml
+# in stack.yaml
+extra-deps:
+- rasa-0.1.0.0
+- rasa-ext-cursors-0.1.0.0
+- rasa-ext-logger-0.1.0.0
+- rasa-ext-status-bar-0.1.0.0
+- rasa-ext-vim-0.1.0.0
+- text-lens-0.1.0.0
+- rasa-ext-files-0.1.0.0
+- rasa-ext-cmd-0.1.0.0
+- rasa-ext-slate-0.1.0.0
+- rasa-ext-style-0.1.0.0
+- vty-5.14
+```
+
 Contributing
 ------------
 
 Things are moving quickly, but I'd love a hand! You can get a rough idea of
 where you can help out at the
 [Roadmap](https://github.com/ChrisPenner/rasa/issues/2), feel free to leave a
-comment there asking any questions, I'm often free to chat, join our [gitter
-here](https://gitter.im/rasa-editor/Lobby)!
+comment there asking any questions. 
+
+Chatting about features is a key part of Rasa's development; come join us in
+the [Chat Room](https://gitter.im/rasa-editor/Lobby)!

--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,28 @@
 machine:
   ghc:
       version: 7.10.1
+
 dependencies:
   pre:
+    - sudo mkdir /nix
+    - sudo chown ubuntu /nix
+    - bash <(curl https://nixos.org/nix/install)
+    - echo "source ~/.nix-profile/etc/profile.d/nix.sh" >> ~/.circlerc
     - wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
     - echo 'deb http://download.fpcomplete.com/ubuntu/precise stable main'|sudo tee /etc/apt/sources.list.d/fpco.list
     - sudo apt-get update && sudo apt-get -y install stack
+
   override:
     - stack --version
     - stack --install-ghc --no-terminal build --only-snapshot -j 1
+
   cache_directories:
     - ~/.stack
+    - /nix/store
 
 test:
   pre:
     - stack build
+
   override:
     - stack test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,12 @@
 flags: {}
 extra-package-dbs: []
+
+nix:
+  enable: true
+  packages:
+    - libcxx
+    - icu
+
 packages:
 - ./rasa
 - ./rasa-ext-cmd
@@ -18,10 +25,13 @@ extra-deps:
 - vty-5.14
 - recursion-schemes-5.0.1
 
-extra-lib-dirs:
-- /usr/local/opt/icu4c/lib 
-extra-include-dirs:
-- /usr/local/opt/icu4c/include
+# Uncomment the following if you'd like to use a locally installed version
+# of icu4c INSTEAD of relying on nix.
+#
+# extra-lib-dirs:
+# - /usr/local/opt/icu4c/lib
+# extra-include-dirs:
+# - /usr/local/opt/icu4c/include
 
 resolver: lts-7.11
 pvp-bounds: both


### PR DESCRIPTION
Uses nix for handling c-lib dependencies for better reproducibility and less user burden.

Still run via `stack build && stack exec rasa`.