### PR TITLE
Event return values

### DIFF
--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -12,6 +12,8 @@ import Rasa.Ext.Logger
 import Rasa.Ext.Cursors
 import Rasa.Ext.Slate
 
+import Control.Monad
+
 -- | This is the main of an executable that runs rasa with any extensions the
 -- user wants
 --
@@ -27,4 +29,4 @@ main = rasa $ do
   logger
   slate
   style
-  onInit $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"
+  onInit . void $ newBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
@@ -4,7 +4,6 @@ module Rasa.Ext.Slate.Internal.Render (render) where
 import Rasa.Ext
 import Rasa.Ext.Views
 import Rasa.Ext.Style
--- import Rasa.Ext.StatusBar (left, center, right)
 import Rasa.Ext.Slate.Internal.State
 import Rasa.Ext.Slate.Internal.Attributes
 import Data.Functor.Foldable

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -29,19 +29,19 @@ rasa initialize = do
   (output, input) <- spawn unbounded
   evalAction (mkActionState output) $ do
     initialize
-    dispatchEvent Init
+    dispatchEvent_ Init
     eventLoop $ fromInput input
-    dispatchEvent Exit
+    dispatchEvent_ Exit
 
 -- | This is the main event loop, it runs recursively forever until something
 -- sets 'Rasa.Editor.exiting'. It runs the pre-event listeners, then checks if any
 -- async events have finished, then runs the post event listeners and repeats.
 eventLoop :: Producer (Action ()) IO () -> Action ()
 eventLoop producer = do
-  dispatchEvent BeforeRender
-  dispatchEvent OnRender
-  dispatchEvent AfterRender
-  dispatchEvent BeforeEvent
+  dispatchEvent_ BeforeRender
+  dispatchEvent_ OnRender
+  dispatchEvent_ AfterRender
+  dispatchEvent_ BeforeEvent
   (mAction, nextProducer) <- liftIO $ runStateT draw producer
   fromMaybe (return ()) mAction
   isExiting <- shouldExit

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -126,6 +126,7 @@ module Rasa.Ext
   -- * Dealing with events
   , ListenerId
   , dispatchEvent
+  , dispatchEvent_
   , onEveryTrigger
   , onEveryTrigger_
   , removeListener

--- a/rasa/src/Rasa/Internal/Actions.hs
+++ b/rasa/src/Rasa/Internal/Actions.hs
@@ -51,7 +51,7 @@ newBuffer :: Y.YiString -> Action BufRef
 newBuffer txt = do
   bufRef <- addBuffer
   void $ bufferDo [bufRef] (setText txt)
-  dispatchEvent (BufAdded bufRef)
+  dispatchEvent_ (BufAdded bufRef)
   return bufRef
 
 -- | Gets 'BufRef' that comes after the one provided

--- a/rasa/src/Rasa/Internal/BufAction.hs
+++ b/rasa/src/Rasa/Internal/BufAction.hs
@@ -77,7 +77,7 @@ bufActionInterpreter (Free bufActionF) =
 
     (SetRange rng newText next) -> do
       text.range rng .= newText
-      lift . dispatchEvent $ BufTextChanged rng newText
+      lift . dispatchEvent_ $ BufTextChanged rng newText
       bufActionInterpreter next
 
     (LiftAction act toNext) -> lift act >>= bufActionInterpreter . toNext


### PR DESCRIPTION
This provides the ability for extensions to actually have return values from event listeners; onEveryTrigger is now type: 

```haskell
onEveryTrigger :: (Typeable event, Typeable response, Monoid response) => (event -> Action response) -> Action ListenerId
```

When you dispatch an event you have the option to return a Monoidal result: 

```haskell
dispatchEvent :: (Typeable event, Typeable response, Monoid response) => event -> Action response
```

It calls all corresponding listeners; mconcats the results together; or returns mempty if no listeners exist.

I plan to use this to for some nifty things going forwards; for instance collecting styling information from all extensions before rendering; collecting status-bar information; rendering information, etc.

If anyone has opinions I'd love to hear them!