### PR TITLE
Implement event-system using Extension infrastructure

### DIFF
--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -1,4 +1,4 @@
-{-# language OverloadedStrings #-}
+{-# language OverloadedStrings, RankNTypes #-}
 module Main where
 
 import Rasa (rasa)

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Event.hs
@@ -11,9 +11,9 @@ import qualified Graphics.Vty as V
 terminalEvents :: Action ()
 terminalEvents = do
     v <- getVty
-    asyncEventProvider $ getEvents v
+    asyncActionProvider $ getEvents v
       where
-        getEvents v dispatch = forever $ V.nextEvent v >>= dispatch . convertEvent
+        getEvents v dispatch = forever $ V.nextEvent v >>= dispatch . dispatchKeypress . convertEvent
 
 -- | Converts a 'V.Event' into a keypress if possible.
 convertEvent :: V.Event -> Keypress

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Render.hs
@@ -86,7 +86,7 @@ renderView (width, height) (vw, buf) = appendActiveBar . resize . addEndBar $ te
     txt :: Y.YiString
     txt = buf^.text & trimText
     adjustedStyles :: [Span CrdRange V.Attr]
-    adjustedStyles = bimap adjustStylePositions convertStyle <$> buf^.bufExt.styles
+    adjustedStyles = bimap adjustStylePositions convertStyle <$> buf^.ext.styles
     adjustStylePositions :: CrdRange -> CrdRange
     adjustStylePositions = both.coordRow -~ vw^.scrollPos
     sepBar :: V.Image

--- a/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
+++ b/rasa-ext-views/src/Rasa/Ext/Views/Internal/Actions.hs
@@ -66,8 +66,8 @@ vSplit :: Action ()
 vSplit = V.overWindows V.vSplit
 
 -- | Add a new split at the top level in the given direction containing the given buffer.
-addSplit :: BufRef -> Action ()
-addSplit bRef = do
+addSplit :: BufAdded -> Action ()
+addSplit (BufAdded bRef) = do
   mWin <- V.getWindows
   case mWin of
     Nothing -> V.setWindows $ Leaf (V.View True bRef 0)

--- a/rasa-ext-vim/rasa-ext-vim.cabal
+++ b/rasa-ext-vim/rasa-ext-vim.cabal
@@ -21,7 +21,6 @@ library
                      , rasa-ext-files
                      , rasa-ext-views
                      , rasa-ext-cursors
-                     , rasa-ext-status-bar
                      , text
                      , yi-rope
                      , text-lens

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -7,7 +7,6 @@ import Rasa.Ext
 import Rasa.Ext.Views
 import Rasa.Ext.Files (save)
 import Rasa.Ext.Cursors
-import Rasa.Ext.StatusBar
 
 import Control.Monad
 import Control.Lens
@@ -55,12 +54,7 @@ addHist keypress = overBufExt extend
 -- >    vim
 -- >    ...
 vim :: Action ()
-vim = do
-  -- Register to listen for keypresses
-  -- onEveryTrigger_ handleKeypress
-  onKeypress handleKeypress
-  -- Set the status bar to the current mode before each render
-  beforeEveryRender_ setStatus
+vim = void $ onKeypress handleKeypress
 
 -- | The event listener which listens for keypresses and responds appropriately
 handleKeypress :: Keypress -> Action ()
@@ -74,14 +68,6 @@ handleKeypress keypress = focusDo_ $ do
   VimHist postHist <- getBufExt
   -- If nothing changed than an action must have happened
   unless (preHist /= postHist) (setBufExt $ VimHist [])
-
--- | Sets the status bar to the current mode and current VimHist
-setStatus :: Action ()
-setStatus = focusDo_ $ do
-  mode <- getBufExt :: BufAction VimMode
-  VimHist hist <- getBufExt
-  centerStatus $ Y.fromString . show $ mode
-  rightStatus $ Y.fromString . show $ hist
 
 -- | Listeners for keypresses that run regardless of current mode.
 anyMode :: [Keypress] -> BufAction ()

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -57,7 +57,8 @@ addHist keypress = overBufExt extend
 vim :: Action ()
 vim = do
   -- Register to listen for keypresses
-  onEveryTrigger_ handleKeypress
+  -- onEveryTrigger_ handleKeypress
+  onKeypress handleKeypress
   -- Set the status bar to the current mode before each render
   beforeEveryRender_ setStatus
 

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -62,6 +62,7 @@ library
                        Rasa.Internal.Editor
                        Rasa.Internal.Events
                        Rasa.Internal.Extensions
+                       Rasa.Internal.Interpreters
                        Rasa.Internal.Listeners
                        Rasa.Internal.Range
                        Rasa.Internal.Text

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -1,8 +1,8 @@
 {-# language ExistentialQuantification, Rank2Types, ScopedTypeVariables #-}
 module Rasa (rasa) where
 
+import Rasa.Internal.Listeners
 import Rasa.Internal.Action
-import Rasa.Internal.Events
 
 import Control.Monad
 import Control.Monad.IO.Class
@@ -29,19 +29,19 @@ rasa initialize = do
   (output, input) <- spawn unbounded
   evalAction (mkActionState output) $ do
     initialize
-    dispatchEvent Init
+    dispatchInit
     eventLoop $ fromInput input
-    dispatchEvent Exit
+    dispatchExit
 
 -- | This is the main event loop, it runs recursively forever until something
 -- sets 'Rasa.Editor.exiting'. It runs the pre-event listeners, then checks if any
 -- async events have finished, then runs the post event listeners and repeats.
 eventLoop :: Producer (Action ()) IO () -> Action ()
 eventLoop producer = do
-  dispatchEvent BeforeRender
-  dispatchEvent OnRender
-  dispatchEvent AfterRender
-  dispatchEvent BeforeEvent
+  dispatchBeforeRender
+  dispatchOnRender
+  dispatchAfterRender
+  dispatchBeforeEvent
   (mAction, nextProducer) <- liftIO $ runStateT draw producer
   fromMaybe (return ()) mAction
   isExiting <- shouldExit

--- a/rasa/src/Rasa.hs
+++ b/rasa/src/Rasa.hs
@@ -3,6 +3,7 @@ module Rasa (rasa) where
 
 import Rasa.Internal.Listeners
 import Rasa.Internal.Action
+import Rasa.Internal.Interpreters
 
 import Control.Monad
 import Control.Monad.IO.Class

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -181,10 +181,13 @@ module Rasa.Ext
   , asString
   , asLines
   , clamp
+
+  , onKeypress
+  , dispatchKeypress
   ) where
 
 import Rasa.Internal.Action
-import Rasa.Internal.Actions
+import Rasa.Internal.Actions hiding (ListenerId)
 import Rasa.Internal.BufAction
 import Rasa.Internal.BufActions
 import Rasa.Internal.Buffer

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -24,13 +24,14 @@
 --
 -- > logKeypress :: Keypress -> Action ()
 -- > logKeypress (Keypress char _) = liftIO $ appendFile "logs" ("You pressed " ++ [char] ++ "\n")
+-- > logKeypress _ = return ()
 -- >
 -- > logger :: Action ()
 -- > logger = do
 -- >   onInit $ liftIO $ writeFile "logs" "==Logs==\n"
 -- >   -- Listeners should also be registered using 'onInit'.
 -- >   -- It ensures all listeners are ready before any actions occur.
--- >   onInit $ onEveryTrigger_ logKeypress
+-- >   onInit $ onKeypress logKeypress
 -- >   onExit $ liftIO $ appendFile "logs" "==Done=="
 --
 -- Check out this tutorial on building extensions, it's also just a great way to learn
@@ -86,7 +87,8 @@ module Rasa.Ext
   -- it.
   --
   -- Because Extension states are stored by their 'Data.Typeable.TypeRep', they must define an
-  -- instance of 'Data.Typeable.Typeable', luckily GHC can derive this for you.
+  -- instance of 'Data.Typeable.Typeable', luckily GHC can derive this for you with
+  -- @deriving Typeable@.
   --
   -- It is also required for all extension states to define an instance of
   -- 'Data.Default.Default', this is because accessing an extension which has not
@@ -106,8 +108,9 @@ module Rasa.Ext
   -- it'll all work out.
   --
   -- Since it's polymorphic, if ghc can't figure out the type the result is
-  -- supposed to be then you'll need to help it out. In practice you won't
-  -- typically need to do this unless you're doing something complicated.
+  -- supposed to be then you'll need to help it out with a type annotation. 
+  -- In practice you won't typically need to do this unless you're 
+  -- doing something complicated.
   , HasExts(..)
   , ext
   , getExt
@@ -120,36 +123,36 @@ module Rasa.Ext
   , overBufExt
 
   -- * Events
-  , Keypress(..)
-  , BufAdded(..)
-  , Mod(..)
-
-  -- * Dealing with events
+  , dispatchEvent
+  , addListener
   , ListenerId
+
+  -- * Built-in Events
+  , Keypress(..)
+  , Mod(..)
+  , BufAdded(..)
+  , BufTextChanged(..)
 
   -- * Built-in Event Listeners
   , onInit
-  , dispatchInit
   , beforeEveryEvent
   , beforeEveryEvent_
   , beforeEveryRender
   , beforeEveryRender_
-  , dispatchBeforeRender
   , onEveryRender
   , onEveryRender_
-  , dispatchOnRender
   , afterEveryRender
   , afterEveryRender_
-  , dispatchAfterRender
   , onExit
-  , dispatchExit
   , onBufAdded
   , onBufTextChanged
 
   -- * Working with Async Events/Actions
-  , Dispatcher
   , dispatchActionAsync
+  , dispatchEventAsync
   , asyncActionProvider
+  , asyncEventProvider
+  , Dispatcher
 
    -- * Ranges
   , Range(..)

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -108,8 +108,8 @@ module Rasa.Ext
   -- it'll all work out.
   --
   -- Since it's polymorphic, if ghc can't figure out the type the result is
-  -- supposed to be then you'll need to help it out with a type annotation. 
-  -- In practice you won't typically need to do this unless you're 
+  -- supposed to be then you'll need to help it out with a type annotation.
+  -- In practice you won't typically need to do this unless you're
   -- doing something complicated.
   , HasExts(..)
   , ext
@@ -123,13 +123,37 @@ module Rasa.Ext
   , overBufExt
 
   -- * Events
+
+  -- | 'dispatchEvent' and 'addListener' are key parts of working with extensions.
+  -- Here's an example of how you might use them in some sort of clipboard extensions:
+  --
+  -- > -- The event type which is triggered whenever something is copied to clipboard
+  -- > data Copied = Copied Y.YiString
+  -- >
+  -- > -- This registers functions to be run when something is copied.
+  -- > -- you can see this is just addListener but with a more concrete type.
+  -- > onCopy :: (Copied -> Action ()) -> Action ListenerId
+  -- > onCopy = addListener
+  -- >
+  -- > -- This takes a Copied event and runs all the listeners associated.
+  -- > -- You can see it's just 'dispatchEvent' with a more concrete type.
+  -- > doCopy :: Copied -> Action ()
+  -- > doCopy = dispatchEvent
+  -- >
+  -- > copier :: Action ()
+  -- > copier = do
+  -- > -- ... do some stuff
+  -- > doCopy $ Copied copiedTxt
+  --
   , dispatchEvent
   , addListener
+  , removeListener
   , ListenerId
 
   -- * Built-in Events
   , Keypress(..)
   , Mod(..)
+  , dispatchKeypress
   , BufAdded(..)
   , BufTextChanged(..)
 
@@ -146,6 +170,7 @@ module Rasa.Ext
   , onExit
   , onBufAdded
   , onBufTextChanged
+  , onKeypress
 
   -- * Working with Async Events/Actions
   , dispatchActionAsync
@@ -184,9 +209,6 @@ module Rasa.Ext
   , asString
   , asLines
   , clamp
-
-  , onKeypress
-  , dispatchKeypress
   ) where
 
 import Rasa.Internal.Action

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Rank2Types, FlexibleContexts #-}
-
 ----------------------------------------------------------------------------
 -- |
 -- Module      :  Rasa.Ext
@@ -146,10 +144,12 @@ module Rasa.Ext
   --
   , dispatchEvent
   , addListener
+  , addListener_
   , removeListener
 
   , dispatchBufEvent
   , addBufListener
+  , addBufListener_
   , removeBufListener
 
   , ListenerId

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -116,8 +116,7 @@ module Rasa.Ext
   , getExt
   , setExt
   , overExt
-  , HasBufExts
-  , bufExt
+
   , getBufExt
   , setBufExt
   , overBufExt
@@ -148,6 +147,11 @@ module Rasa.Ext
   , dispatchEvent
   , addListener
   , removeListener
+
+  , dispatchBufEvent
+  , addBufListener
+  , removeBufListener
+
   , ListenerId
 
   -- * Built-in Events

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -121,34 +121,34 @@ module Rasa.Ext
 
   -- * Events
   , Keypress(..)
+  , BufAdded(..)
   , Mod(..)
 
   -- * Dealing with events
   , ListenerId
-  , dispatchEvent
-  , onEveryTrigger
-  , onEveryTrigger_
-  , removeListener
 
   -- * Built-in Event Listeners
   , onInit
+  , dispatchInit
   , beforeEveryEvent
   , beforeEveryEvent_
   , beforeEveryRender
   , beforeEveryRender_
+  , dispatchBeforeRender
   , onEveryRender
   , onEveryRender_
+  , dispatchOnRender
   , afterEveryRender
   , afterEveryRender_
+  , dispatchAfterRender
   , onExit
+  , dispatchExit
   , onBufAdded
   , onBufTextChanged
 
   -- * Working with Async Events/Actions
   , Dispatcher
   , dispatchActionAsync
-  , dispatchEventAsync
-  , asyncEventProvider
   , asyncActionProvider
 
    -- * Ranges
@@ -187,7 +187,7 @@ module Rasa.Ext
   ) where
 
 import Rasa.Internal.Action
-import Rasa.Internal.Actions hiding (ListenerId)
+import Rasa.Internal.Actions
 import Rasa.Internal.BufAction
 import Rasa.Internal.BufActions
 import Rasa.Internal.Buffer

--- a/rasa/src/Rasa/Internal/Action.hs
+++ b/rasa/src/Rasa/Internal/Action.hs
@@ -17,9 +17,7 @@ module Rasa.Internal.Action
 import Rasa.Internal.ActionMonads
 import Rasa.Internal.Editor
 import Rasa.Internal.Buffer
-
-import Data.Default
-import Data.Typeable
+import Rasa.Internal.Extensions
 
 -- | dispatchActionAsync allows you to perform a task asynchronously and then apply the
 -- result. In @dispatchActionAsync asyncAction@, @asyncAction@ is an IO which resolves to
@@ -90,18 +88,6 @@ addBuffer = liftActionF $ AddBuffer id
 -- | Returns an up-to-date list of all 'BufRef's
 getBufRefs :: Action [BufRef]
 getBufRefs = liftActionF $ GetBufRefs id
-
--- | Retrieve some extension state
-getExt :: (Typeable ext, Show ext, Default ext) => Action ext
-getExt = liftActionF $ GetExt id
-
--- | Set some extension state
-setExt :: (Typeable ext, Show ext, Default ext) => ext -> Action ()
-setExt newExt = liftActionF $ SetExt newExt ()
-
--- | Set some extension state
-overExt :: (Typeable ext, Show ext, Default ext) => (ext -> ext) -> Action ()
-overExt f = getExt >>= setExt . f
 
 -- | Retrieve the entire editor state. This is read-only for logging/rendering/debugging purposes only.
 getEditor :: Action Editor

--- a/rasa/src/Rasa/Internal/ActionMonads.hs
+++ b/rasa/src/Rasa/Internal/ActionMonads.hs
@@ -14,6 +14,7 @@ module Rasa.Internal.ActionMonads
   ) where
 
 import Rasa.Internal.Editor
+import Rasa.Internal.Extensions
 import Rasa.Internal.Buffer
 import Rasa.Internal.Range
 
@@ -51,6 +52,13 @@ liftFIO = liftActionF . LiftIO
 
 instance MonadIO Action where
   liftIO = liftFIO
+
+instance HasExtMonad Action where
+  -- | Retrieve some extension state
+  getExt = liftActionF $ GetExt id
+
+  -- | Set some extension state
+  setExt newExt = liftActionF $ SetExt newExt ()
 
 -- | This is a monad for performing actions against the editor.
 -- You can register Actions to be run in response to events using 'Rasa.Internal.Listeners.onEveryTrigger'
@@ -102,3 +110,10 @@ liftBufActionFIO = liftBufAction . BufLiftIO
 
 instance MonadIO BufAction where
   liftIO = liftBufActionFIO
+
+instance HasExtMonad BufAction where
+  -- | Retrieve some buffer extension state
+  getExt = liftBufAction $ GetBufExt id
+
+  -- | Set some buffer extension state
+  setExt newExt = liftBufAction $ SetBufExt newExt ()

--- a/rasa/src/Rasa/Internal/Actions.hs
+++ b/rasa/src/Rasa/Internal/Actions.hs
@@ -1,4 +1,9 @@
-{-# language Rank2Types, OverloadedStrings #-}
+{-# language
+    Rank2Types
+  , OverloadedStrings
+  , GADTs
+  , ScopedTypeVariables
+#-}
 module Rasa.Internal.Actions
   (
   -- * Performing Actions on Buffers
@@ -13,15 +18,24 @@ module Rasa.Internal.Actions
   , getBufRefs
   , nextBufRef
   , prevBufRef
+
+  , mkRegistrar
+  , mkDispatcher
+  , ListenerId
   ) where
 
 import Rasa.Internal.Editor
-import Rasa.Internal.Action
+import Rasa.Internal.Action hiding (Listener, Listeners, ListenerId, listeners, nextListenerId)
 import Rasa.Internal.BufAction
 import Rasa.Internal.Events
 
 import Control.Monad
+import Control.Lens
+import Data.Default
 import Data.Maybe
+import Data.Typeable
+
+import qualified Data.Map as M
 import qualified Yi.Rope as Y
 
 
@@ -74,3 +88,62 @@ prevBufRef br = do
                      [] -> last bufRefs
                      (x:_) -> x
 
+
+
+-- | A wrapper around event listeners so they can be stored in 'Listeners'.
+data Listener where
+  Listener :: Typeable eventType => ListenerId -> (eventType -> Action ()) -> Listener
+
+-- | An opaque reverence to a specific registered event-listener.
+-- A ListenerId is used only to remove listeners later with 'Rasa.Internal.Listeners.removeListener'.
+data ListenerId =
+  ListenerId Int TypeRep
+
+instance Eq ListenerId where
+  ListenerId a _ == ListenerId b _ = a == b
+
+-- | A map of Event types to a list of listeners for that event
+type Listeners = M.Map TypeRep [Listener]
+
+data L = L Int Listeners
+
+instance Show L where
+  show _ = "Listeners"
+
+instance Default L where
+  def = L 0 M.empty
+
+mkDispatcher :: forall result eventType. (Monoid result, Typeable eventType, Typeable result) => (eventType -> Action result)
+mkDispatcher = dispatcher
+  where
+    dispatcher :: eventType -> Action result
+    dispatcher evt = do
+      L _ listeners <- getExt
+      results <- traverse ($ evt) (matchingListeners listeners)
+      return $ mconcat results
+
+mkRegistrar :: forall result eventType. (Typeable eventType) => (eventType -> Action result) -> Action ListenerId
+mkRegistrar = registrar
+  where
+    registrar :: (eventType -> Action result) -> Action ListenerId
+    registrar lFunc = do
+      L nextListenerId listeners  <- getExt
+      let (listener, listenerId, eventType) = mkListener nextListenerId lFunc
+          newListeners = M.insertWith mappend eventType [listener] listeners
+      setExt $ L (nextListenerId + 1) newListeners
+      return listenerId
+
+    mkListener :: forall event r. Typeable event => Int -> (event -> Action r) -> (Listener, ListenerId, TypeRep)
+    mkListener n listenerFunc =
+      let list = Listener listId (void . listenerFunc)
+          listId = ListenerId n (typeRep (Proxy :: Proxy event))
+          prox = typeRep (Proxy :: Proxy event)
+        in (list, listId, prox)
+
+-- | This extracts all event listeners from a map of listeners which match the type of the provided event.
+matchingListeners :: forall eventType result. (Typeable eventType, Typeable result) => Listeners -> [eventType -> Action result]
+matchingListeners listeners' = catMaybes $ getListener <$> (listeners'^.at (typeRep (Proxy :: Proxy eventType))._Just)
+
+-- | Extract the listener function from eventType listener
+getListener :: forall eventType r. (Typeable eventType, Typeable r) => Listener -> Maybe (eventType -> Action r)
+getListener (Listener _ x) = cast x

--- a/rasa/src/Rasa/Internal/BufAction.hs
+++ b/rasa/src/Rasa/Internal/BufAction.hs
@@ -17,7 +17,6 @@ module Rasa.Internal.BufAction
 import Rasa.Internal.ActionMonads
 import Rasa.Internal.Buffer
 import Rasa.Internal.Range
-import Rasa.Internal.Events
 import Rasa.Internal.Extensions
 
 import Control.Lens
@@ -77,7 +76,7 @@ bufActionInterpreter (Free bufActionF) =
 
     (SetRange rng newText next) -> do
       text.range rng .= newText
-      lift . dispatchEvent $ BufTextChanged rng newText
+      -- lift . bufTextChanged $ BufTextChanged rng newText
       bufActionInterpreter next
 
     (LiftAction act toNext) -> lift act >>= bufActionInterpreter . toNext

--- a/rasa/src/Rasa/Internal/BufAction.hs
+++ b/rasa/src/Rasa/Internal/BufAction.hs
@@ -1,6 +1,3 @@
-{-# language DeriveFunctor
-  , ExistentialQuantification
-#-}
 module Rasa.Internal.BufAction
   ( BufAction(..)
   , getText
@@ -11,17 +8,12 @@ module Rasa.Internal.BufAction
   , setBufExt
   , overBufExt
   , liftAction
-  , runBufAction
   ) where
 
 import Rasa.Internal.ActionMonads
-import Rasa.Internal.Buffer
 import Rasa.Internal.Range
-import Rasa.Internal.Extensions
 
 import Control.Lens
-import Control.Monad.Free
-import Control.Monad.State
 import Data.Default
 import Data.Typeable
 
@@ -44,51 +36,17 @@ setRange :: CrdRange -> Y.YiString -> BufAction ()
 setRange rng txt = liftBufAction $ SetRange rng txt ()
 
 -- | Retrieve some buffer extension state
-getBufExt :: forall ext. (Typeable ext, Show ext, Default ext) => BufAction ext
+getBufExt :: (Typeable ext, Show ext, Default ext) => BufAction ext
 getBufExt = liftBufAction $ GetBufExt id
 
 -- | Set some buffer extension state
-setBufExt :: forall ext. (Typeable ext, Show ext, Default ext) => ext -> BufAction ()
+setBufExt :: (Typeable ext, Show ext, Default ext) => ext -> BufAction ()
 setBufExt newExt = liftBufAction $ SetBufExt newExt ()
 
 -- | Set some buffer extension state
-overBufExt :: forall ext. (Typeable ext, Show ext, Default ext) => (ext -> ext) -> BufAction ()
+overBufExt :: (Typeable ext, Show ext, Default ext) => (ext -> ext) -> BufAction ()
 overBufExt f = getBufExt >>= setBufExt . f
 
 -- | This lifts up an 'Action' to be run inside a 'BufAction'
 liftAction :: Action r -> BufAction r
 liftAction action = liftBufAction $ LiftAction action id
-
--- | This lifts up a bufAction into an Action which performs the 'BufAction'
--- over the referenced buffer and returns the result (if the buffer existed)
-runBufAction :: BufAction a -> Buffer -> Action (a, Buffer)
-runBufAction (BufAction bufActF) buf = flip runStateT buf $ bufActionInterpreter bufActF
-
--- | Interpret the Free Monad; in this case it interprets it down to an Action.
-bufActionInterpreter :: Free BufActionF r -> StateT Buffer Action r
-bufActionInterpreter (Free bufActionF) =
-  case bufActionF of
-    (GetText nextF) -> use text >>= bufActionInterpreter . nextF
-
-    (SetText newText next) -> do
-      text .= newText
-      bufActionInterpreter next
-
-    (SetRange rng newText next) -> do
-      text.range rng .= newText
-      -- lift . bufTextChanged $ BufTextChanged rng newText
-      bufActionInterpreter next
-
-    (LiftAction act toNext) -> lift act >>= bufActionInterpreter . toNext
-
-    (GetBufExt extToNext) ->
-      use bufExt >>= bufActionInterpreter . extToNext
-
-    (SetBufExt new next) -> do
-      bufExt .= new
-      bufActionInterpreter next
-
-    (BufLiftIO ioNext) ->
-      liftIO ioNext >>= bufActionInterpreter
-
-bufActionInterpreter (Pure res) = return res

--- a/rasa/src/Rasa/Internal/Buffer.hs
+++ b/rasa/src/Rasa/Internal/Buffer.hs
@@ -33,12 +33,12 @@ makeLenses ''Buffer
 instance Default Buffer where
   def = Buffer def def
 
-instance HasBufExts Buffer where
-  bufExts = bufExts'
+instance HasExts Buffer where
+  exts = bufExts'
 
 instance Show Buffer where
   show b = "<Buffer {text:" ++ show (b^..text . to (Y.take 30)) ++ "...,\n"
-           ++ "exts: " ++ show (b^.bufExts) ++ "}>\n"
+           ++ "exts: " ++ show (b^.exts) ++ "}>\n"
 
 -- | This allows creation of polymorphic lenses over any type which has access to a Buffer
 class HasBuffer a where

--- a/rasa/src/Rasa/Internal/Interpreters.hs
+++ b/rasa/src/Rasa/Internal/Interpreters.hs
@@ -1,0 +1,169 @@
+{-# language
+    TemplateHaskell
+#-}
+
+module Rasa.Internal.Interpreters
+  ( runAction
+  , evalAction
+  , execAction
+  , bootstrapAction
+  , mkActionState
+
+  , runBufAction
+  ) where
+
+import Rasa.Internal.ActionMonads
+import Rasa.Internal.Buffer
+import Rasa.Internal.Editor
+import Rasa.Internal.Events hiding (Exit)
+import Rasa.Internal.Extensions
+import Rasa.Internal.Listeners
+import Rasa.Internal.Range
+
+import Control.Monad.Free
+import Control.Monad.State
+import Control.Lens
+import Data.Default
+import Data.Maybe
+import qualified Data.IntMap as IM
+
+import Pipes hiding (Proxy, next)
+import Pipes.Concurrent hiding (Buffer)
+
+-- | This contains all data representing the editor's state. It acts as the state object for an 'Action
+data ActionState = ActionState
+  { _ed :: Editor
+  , _nextBufId :: Int
+  , _actionQueue :: Output (Action ())
+  }
+makeLenses ''ActionState
+
+instance Show ActionState where
+  show as = show (_ed as)
+
+mkActionState :: Output (Action ()) -> ActionState
+mkActionState out = ActionState
+    { _ed=def
+    , _nextBufId=0
+    , _actionQueue=out
+    }
+
+instance HasEditor ActionState where
+  editor = ed
+
+instance HasExts ActionState where
+  exts = ed.exts
+
+-- | Runs an Action into an IO
+runAction :: ActionState -> Action a -> IO (a, ActionState)
+runAction actionState (Action actionF) = flip runStateT actionState $ actionInterpreter actionF
+
+-- | Evals an Action into an IO
+evalAction :: ActionState -> Action a -> IO a
+evalAction actionState action = fst <$> runAction actionState action
+
+-- | Execs an Action into an IO
+execAction :: ActionState -> Action a -> IO ActionState
+execAction actionState action = snd <$> runAction actionState action
+
+-- | Spawn the channels necessary to run action and do so.
+bootstrapAction :: Action a -> IO a
+bootstrapAction action = do
+    (output, _) <- spawn unbounded
+    evalAction (mkActionState output) action
+
+-- | Interpret the Free Monad; in this case it interprets it down to an IO
+actionInterpreter :: Free ActionF r -> StateT ActionState IO r
+actionInterpreter (Free actionF) =
+  case actionF of
+    (LiftIO ioNext) ->
+      liftIO ioNext >>= actionInterpreter
+
+    (BufferDo bufRefs bufAct toNext) -> do
+      results <- forM bufRefs $ \(BufRef bInd) ->
+        use (buffers.at bInd) >>= traverse (handleBuf bInd)
+      actionInterpreter . toNext $ catMaybes results
+        where handleBuf bIndex buf = do
+                let Action act = runBufAction bufAct buf
+                (res, newBuffer) <- actionInterpreter act
+                buffers.at bIndex ?= newBuffer
+                return res
+
+    (DispatchActionAsync asyncActionIO next) -> do
+      asyncQueue <- use actionQueue
+      let effect = (liftIO asyncActionIO >>= yield) >-> toOutput asyncQueue
+      liftIO . void . forkIO $ runEffect effect >> performGC
+      actionInterpreter next
+
+    (AsyncActionProvider dispatcherToIO next) -> do
+      asyncQueue <- use actionQueue
+      let dispatcher action =
+            let effect = yield action >-> toOutput asyncQueue
+             in void . forkIO $ runEffect effect >> performGC
+      liftIO . void . forkIO $ dispatcherToIO dispatcher
+      actionInterpreter next
+
+    (AddBuffer toNext) -> do
+      bufId <- nextBufId <+= 1
+      buffers.at bufId ?= def
+      actionInterpreter . toNext $ BufRef bufId
+
+    (GetBufRefs toNext) ->
+      use (buffers.to IM.keys) >>= actionInterpreter . toNext . fmap BufRef
+
+    (GetExt toNext) ->
+      use ext >>= actionInterpreter . toNext
+
+    (SetExt new next) -> do
+      ext .= new
+      actionInterpreter next
+
+    (GetEditor toNext) ->
+      use ed >>= actionInterpreter . toNext
+
+    (GetBuffer (BufRef bufInd) toNext) ->
+      use (buffers.at bufInd) >>= actionInterpreter . toNext
+
+    (Exit next) -> do
+      exiting .= True
+      actionInterpreter next
+
+    (ShouldExit toNext) -> do
+      ex <- use exiting
+      actionInterpreter (toNext ex)
+
+actionInterpreter (Pure res) = return res
+
+-- | This lifts up a bufAction into an Action which performs the 'BufAction'
+-- over the referenced buffer and returns the result (if the buffer existed)
+runBufAction :: BufAction a -> Buffer -> Action (a, Buffer)
+runBufAction (BufAction bufActF) buf = flip runStateT buf $ bufActionInterpreter bufActF
+
+-- | Interpret the Free Monad; in this case it interprets it down to an Action.
+bufActionInterpreter :: Free BufActionF r -> StateT Buffer Action r
+bufActionInterpreter (Free bufActionF) =
+  case bufActionF of
+    (GetText nextF) -> use text >>= bufActionInterpreter . nextF
+
+    (SetText newText next) -> do
+      text .= newText
+      bufActionInterpreter next
+
+    (SetRange rng newText next) -> do
+      text.range rng .= newText
+      lift . dispatchBufTextChanged $ BufTextChanged rng newText
+      bufActionInterpreter next
+
+    (LiftAction act toNext) -> lift act >>= bufActionInterpreter . toNext
+
+    (GetBufExt extToNext) ->
+      use bufExt >>= bufActionInterpreter . extToNext
+
+    (SetBufExt new next) -> do
+      bufExt .= new
+      bufActionInterpreter next
+
+    (BufLiftIO ioNext) ->
+      liftIO ioNext >>= bufActionInterpreter
+
+bufActionInterpreter (Pure res) = return res

--- a/rasa/src/Rasa/Internal/Interpreters.hs
+++ b/rasa/src/Rasa/Internal/Interpreters.hs
@@ -157,10 +157,10 @@ bufActionInterpreter (Free bufActionF) =
     (LiftAction act toNext) -> lift act >>= bufActionInterpreter . toNext
 
     (GetBufExt extToNext) ->
-      use bufExt >>= bufActionInterpreter . extToNext
+      use ext >>= bufActionInterpreter . extToNext
 
     (SetBufExt new next) -> do
-      bufExt .= new
+      ext .= new
       bufActionInterpreter next
 
     (BufLiftIO ioNext) ->

--- a/rasa/src/Rasa/Internal/Listeners.hs
+++ b/rasa/src/Rasa/Internal/Listeners.hs
@@ -1,53 +1,52 @@
 {-# LANGUAGE ExistentialQuantification, ScopedTypeVariables #-}
 
 module Rasa.Internal.Listeners
-  ( onEveryTrigger
-  , onEveryTrigger_
-  , onInit
-  , beforeEveryEvent
-  , beforeEveryEvent_
+  ( onInit
+  , dispatchInit
   , beforeEveryRender
   , beforeEveryRender_
+  , dispatchBeforeRender
+  , beforeEveryEvent
+  , beforeEveryEvent_
+  , dispatchBeforeEvent
   , onEveryRender
   , onEveryRender_
+  , dispatchOnRender
   , afterEveryRender
   , afterEveryRender_
-  , dispatchEvent
+  , dispatchAfterRender
   , onExit
-  , removeListener
+  , dispatchExit
   , onBufAdded
+  , dispatchBufAdded
   , onBufTextChanged
 
   , onKeypress
   , dispatchKeypress
+  , bufTextChanged
   ) where
 
 
 import Rasa.Internal.Action
-import qualified Rasa.Internal.Actions as A
 import Rasa.Internal.Events
-import Rasa.Internal.Editor
-import Rasa.Internal.Range
 
 import Control.Monad
-import Data.Dynamic
-import qualified Yi.Rope as Y
 
-onKeypress :: (Keypress -> Action ()) -> Action A.ListenerId
-onKeypress = A.mkRegistrar
+onKeypress :: (Keypress -> Action ()) -> Action ListenerId
+onKeypress = mkRegistrar
 
 dispatchKeypress :: Keypress -> Action ()
-dispatchKeypress = A.mkDispatcher
+dispatchKeypress = mkDispatcher
 
 -- | This registers an event listener, as long as the listener is well-typed similar to this:
 --
 -- @MyEventType -> Action ()@ then it will be triggered on all dispatched events of type @MyEventType@.
 -- It returns an ID which may be used with 'removeListener' to cancel the listener
-onEveryTrigger :: Typeable event => (event -> Action b) -> Action ListenerId
-onEveryTrigger = addListener
+-- onEveryTrigger :: Typeable event => (event -> Action b) -> Action ListenerId
+-- onEveryTrigger = addListener
 
-onEveryTrigger_ :: Typeable event => (event -> Action b) -> Action ()
-onEveryTrigger_ = void . onEveryTrigger
+-- onEveryTrigger_ :: Typeable event => (event -> Action b) -> Action ()
+-- onEveryTrigger_ = void . onEveryTrigger
 
 -- | Registers an action to be performed during the Initialization phase.
 --
@@ -55,45 +54,60 @@ onEveryTrigger_ = void . onEveryTrigger
 -- Though arbitrary actions may be performed in the configuration block;
 -- it's recommended to embed such actions in the onInit event listener
 -- so that all event listeners are registered before anything Actions occur.
-onInit :: forall a. Action a -> Action ()
-onInit action = onEveryTrigger_ (const action :: Init -> Action a)
+onInit :: Action a -> Action ()
+onInit action = void $ mkRegistrar (const (void action) :: Init -> Action ())
+
+dispatchInit :: Action ()
+dispatchInit = mkDispatcher Init
 
 -- | Registers an action to be performed BEFORE each event phase.
-beforeEveryEvent :: forall a. Action a -> Action ListenerId
-beforeEveryEvent action = onEveryTrigger (const action :: BeforeEvent -> Action a)
+beforeEveryEvent :: Action a -> Action ListenerId
+beforeEveryEvent action = mkRegistrar (const (void action) :: BeforeEvent -> Action ())
 
-beforeEveryEvent_ :: forall a. Action a -> Action ()
+beforeEveryEvent_ :: Action a -> Action ()
 beforeEveryEvent_ = void . beforeEveryEvent
+
+dispatchBeforeEvent :: Action ()
+dispatchBeforeEvent = mkDispatcher BeforeEvent
 
 -- | Registers an action to be performed BEFORE each render phase.
 --
 -- This is a good spot to add information useful to the renderer
 -- since all actions have been performed. Only cosmetic changes should
 -- occur during this phase.
-beforeEveryRender :: forall a. Action a -> Action ListenerId
-beforeEveryRender action = onEveryTrigger (const action :: BeforeRender -> Action a)
+beforeEveryRender :: Action a -> Action ListenerId
+beforeEveryRender action = mkRegistrar (const (void action) :: BeforeRender -> Action ())
 
-beforeEveryRender_ :: forall a. Action a -> Action ()
+beforeEveryRender_ :: Action a -> Action ()
 beforeEveryRender_ = void . beforeEveryRender
+
+dispatchBeforeRender :: Action ()
+dispatchBeforeRender = mkDispatcher BeforeRender
 
 -- | Registers an action to be performed during each render phase.
 --
 -- This phase should only be used by extensions which actually render something.
-onEveryRender :: forall a. Action a -> Action ListenerId
-onEveryRender action = onEveryTrigger (const action :: OnRender -> Action a)
+onEveryRender :: Action a -> Action ListenerId
+onEveryRender action = mkRegistrar (const $ void action :: OnRender -> Action ())
 
-onEveryRender_ :: forall a. Action a -> Action ()
+onEveryRender_ :: Action a -> Action ()
 onEveryRender_ = void . onEveryRender
+
+dispatchOnRender :: Action ()
+dispatchOnRender = mkDispatcher OnRender
 
 -- | Registers an action to be performed AFTER each render phase.
 --
 -- This is useful for cleaning up extension state that was registered for the
 -- renderer, but needs to be cleared before the next iteration.
-afterEveryRender :: forall a. Action a -> Action ListenerId
-afterEveryRender action = onEveryTrigger (const action :: AfterRender -> Action a)
+afterEveryRender :: Action a -> Action ListenerId
+afterEveryRender action = mkRegistrar (const $ void action :: AfterRender -> Action ())
 
-afterEveryRender_ :: forall a. Action a -> Action ()
+afterEveryRender_ :: Action a -> Action ()
 afterEveryRender_ = void . afterEveryRender
+
+dispatchAfterRender :: Action ()
+dispatchAfterRender = mkDispatcher AfterRender
 
 -- | Registers an action to be performed during the exit phase.
 --
@@ -101,21 +115,26 @@ afterEveryRender_ = void . afterEveryRender
 -- allows an opportunity to do clean-up, kill any processes you've started, or
 -- save any data before the editor terminates.
 
-onExit :: forall a. Action a -> Action ()
-onExit action = onEveryTrigger_ (const action :: Exit -> Action a)
+onExit :: Action a -> Action ()
+onExit action = void $ mkRegistrar (const $ void action :: Exit -> Action ())
+
+dispatchExit :: Action ()
+dispatchExit = mkDispatcher Exit
 
 -- | Registers an action to be performed after a new buffer is added.
 --
 -- The supplied function will be called with a 'BufRef' to the new buffer, and the resulting 'Action' will be run.
-onBufAdded :: forall a. (BufRef -> Action a) -> Action ListenerId
-onBufAdded f = onEveryTrigger listener
-  where
-    listener (BufAdded bRef) = f bRef
+onBufAdded :: (BufAdded -> Action a) -> Action ListenerId
+onBufAdded actionF = mkRegistrar $ void <$> actionF
+
+dispatchBufAdded :: BufAdded -> Action ()
+dispatchBufAdded = mkDispatcher
 
 -- | This is fired every time text in a buffer changes.
 --
 -- The range of text which was altered and the new value of that text are provided inside a 'BufTextChanged' event.
-onBufTextChanged :: forall a. (CrdRange -> Y.YiString -> Action a) -> Action ListenerId
-onBufTextChanged f = onEveryTrigger listener
-  where
-    listener (BufTextChanged r newText) = f r newText
+onBufTextChanged :: (BufTextChanged -> Action a) -> Action ListenerId
+onBufTextChanged actionF = mkRegistrar $ void <$> actionF
+
+bufTextChanged :: BufTextChanged -> Action ()
+bufTextChanged = mkDispatcher

--- a/rasa/src/Rasa/Internal/Listeners.hs
+++ b/rasa/src/Rasa/Internal/Listeners.hs
@@ -1,42 +1,98 @@
-{-# LANGUAGE ExistentialQuantification, ScopedTypeVariables #-}
+{-# language
+  GADTs
+  , ExistentialQuantification
+  , ScopedTypeVariables
+  , RankNTypes
+#-}
 
 module Rasa.Internal.Listeners
-  ( onInit
+  ( dispatchEvent
+  , addListener
+  , Dispatcher
+  , ListenerId
+
+  , onInit
   , dispatchInit
+
   , beforeEveryRender
   , beforeEveryRender_
   , dispatchBeforeRender
+
   , beforeEveryEvent
   , beforeEveryEvent_
   , dispatchBeforeEvent
+
   , onEveryRender
   , onEveryRender_
   , dispatchOnRender
+
   , afterEveryRender
   , afterEveryRender_
   , dispatchAfterRender
+
   , onExit
   , dispatchExit
+
   , onBufAdded
   , dispatchBufAdded
+
   , onBufTextChanged
+  , dispatchBufTextChanged
 
   , onKeypress
   , dispatchKeypress
-  , bufTextChanged
-  ) where
 
+  , asyncEventProvider
+  , dispatchEventAsync
+  ) where
 
 import Rasa.Internal.Action
 import Rasa.Internal.Events
 
+import Control.Lens
 import Control.Monad
+import Data.Default
+import Data.Typeable
+import Data.Maybe
+import qualified Data.Map as M
+
+-- | A wrapper around event listeners so they can be stored in 'Listeners'.
+data Listener where
+  Listener :: Typeable eventType => ListenerId -> (eventType -> Action ()) -> Listener
+
+-- | An opaque reverence to a specific registered event-listener.
+-- A ListenerId is used only to remove listeners later with 'Rasa.Internal.Listeners.removeListener'.
+data ListenerId =
+  ListenerId Int TypeRep
+
+instance Eq ListenerId where
+  ListenerId a _ == ListenerId b _ = a == b
+
+-- | A map of Event types to a list of listeners for that event
+type Listeners = M.Map TypeRep [Listener]
+
+data GlobalListeners = GlobalListeners Int Listeners
+
+instance Show GlobalListeners where
+  show _ = "Listeners"
+
+instance Default GlobalListeners where
+  def = GlobalListeners 0 M.empty
+
+-- | This extracts all event listeners from a map of listeners which match the type of the provided event.
+matchingListeners :: forall eventType result. (Typeable eventType, Typeable result) => Listeners -> [eventType -> Action result]
+matchingListeners listeners' = catMaybes $ getListener <$> (listeners'^.at (typeRep (Proxy :: Proxy eventType))._Just)
+
+-- | Extract the listener function from eventType listener
+getListener :: forall eventType r. (Typeable eventType, Typeable r) => Listener -> Maybe (eventType -> Action r)
+getListener (Listener _ x) = cast x
+
 
 onKeypress :: (Keypress -> Action ()) -> Action ListenerId
-onKeypress = mkRegistrar
+onKeypress = addListener
 
 dispatchKeypress :: Keypress -> Action ()
-dispatchKeypress = mkDispatcher
+dispatchKeypress = dispatchEvent
 
 -- | This registers an event listener, as long as the listener is well-typed similar to this:
 --
@@ -55,20 +111,20 @@ dispatchKeypress = mkDispatcher
 -- it's recommended to embed such actions in the onInit event listener
 -- so that all event listeners are registered before anything Actions occur.
 onInit :: Action a -> Action ()
-onInit action = void $ mkRegistrar (const (void action) :: Init -> Action ())
+onInit action = void $ addListener (const (void action) :: Init -> Action ())
 
 dispatchInit :: Action ()
-dispatchInit = mkDispatcher Init
+dispatchInit = dispatchEvent Init
 
 -- | Registers an action to be performed BEFORE each event phase.
 beforeEveryEvent :: Action a -> Action ListenerId
-beforeEveryEvent action = mkRegistrar (const (void action) :: BeforeEvent -> Action ())
+beforeEveryEvent action = addListener (const (void action) :: BeforeEvent -> Action ())
 
 beforeEveryEvent_ :: Action a -> Action ()
 beforeEveryEvent_ = void . beforeEveryEvent
 
 dispatchBeforeEvent :: Action ()
-dispatchBeforeEvent = mkDispatcher BeforeEvent
+dispatchBeforeEvent = dispatchEvent BeforeEvent
 
 -- | Registers an action to be performed BEFORE each render phase.
 --
@@ -76,38 +132,38 @@ dispatchBeforeEvent = mkDispatcher BeforeEvent
 -- since all actions have been performed. Only cosmetic changes should
 -- occur during this phase.
 beforeEveryRender :: Action a -> Action ListenerId
-beforeEveryRender action = mkRegistrar (const (void action) :: BeforeRender -> Action ())
+beforeEveryRender action = addListener (const (void action) :: BeforeRender -> Action ())
 
 beforeEveryRender_ :: Action a -> Action ()
 beforeEveryRender_ = void . beforeEveryRender
 
 dispatchBeforeRender :: Action ()
-dispatchBeforeRender = mkDispatcher BeforeRender
+dispatchBeforeRender = dispatchEvent BeforeRender
 
 -- | Registers an action to be performed during each render phase.
 --
 -- This phase should only be used by extensions which actually render something.
 onEveryRender :: Action a -> Action ListenerId
-onEveryRender action = mkRegistrar (const $ void action :: OnRender -> Action ())
+onEveryRender action = addListener (const $ void action :: OnRender -> Action ())
 
 onEveryRender_ :: Action a -> Action ()
 onEveryRender_ = void . onEveryRender
 
 dispatchOnRender :: Action ()
-dispatchOnRender = mkDispatcher OnRender
+dispatchOnRender = dispatchEvent OnRender
 
 -- | Registers an action to be performed AFTER each render phase.
 --
 -- This is useful for cleaning up extension state that was registered for the
 -- renderer, but needs to be cleared before the next iteration.
 afterEveryRender :: Action a -> Action ListenerId
-afterEveryRender action = mkRegistrar (const $ void action :: AfterRender -> Action ())
+afterEveryRender action = addListener (const $ void action :: AfterRender -> Action ())
 
 afterEveryRender_ :: Action a -> Action ()
 afterEveryRender_ = void . afterEveryRender
 
 dispatchAfterRender :: Action ()
-dispatchAfterRender = mkDispatcher AfterRender
+dispatchAfterRender = dispatchEvent AfterRender
 
 -- | Registers an action to be performed during the exit phase.
 --
@@ -116,25 +172,90 @@ dispatchAfterRender = mkDispatcher AfterRender
 -- save any data before the editor terminates.
 
 onExit :: Action a -> Action ()
-onExit action = void $ mkRegistrar (const $ void action :: Exit -> Action ())
+onExit action = void $ addListener (const $ void action :: Exit -> Action ())
 
 dispatchExit :: Action ()
-dispatchExit = mkDispatcher Exit
+dispatchExit = dispatchEvent Exit
 
 -- | Registers an action to be performed after a new buffer is added.
 --
 -- The supplied function will be called with a 'BufRef' to the new buffer, and the resulting 'Action' will be run.
 onBufAdded :: (BufAdded -> Action a) -> Action ListenerId
-onBufAdded actionF = mkRegistrar $ void <$> actionF
+onBufAdded actionF = addListener $ void <$> actionF
 
 dispatchBufAdded :: BufAdded -> Action ()
-dispatchBufAdded = mkDispatcher
+dispatchBufAdded = dispatchEvent
 
 -- | This is fired every time text in a buffer changes.
 --
 -- The range of text which was altered and the new value of that text are provided inside a 'BufTextChanged' event.
 onBufTextChanged :: (BufTextChanged -> Action a) -> Action ListenerId
-onBufTextChanged actionF = mkRegistrar $ void <$> actionF
+onBufTextChanged actionF = addListener $ void <$> actionF
 
-bufTextChanged :: BufTextChanged -> Action ()
-bufTextChanged = mkDispatcher
+dispatchBufTextChanged :: BufTextChanged -> Action ()
+dispatchBufTextChanged = dispatchEvent
+
+-- | This is a type alias to make defining your event provider functions easier;
+-- It represents the function your event provider function will be passed to allow dispatching
+-- events. Using this type requires the @RankNTypes@ language pragma.
+type Dispatcher = forall event. Typeable event => event -> IO ()
+
+-- | This allows long-running IO processes to provide Events to Rasa asyncronously.
+--
+-- Don't let the type signature confuse you; it's much simpler than it seems.
+--
+-- Let's break it down:
+--
+-- Using 'dispatchEvent' with asyncEventProvider requires the @RankNTypes@ language pragma.
+--
+-- This type as a whole represents a function which accepts a 'dispatchEvent' and returns an 'IO';
+-- the dispatchEvent itself accepts data of ANY 'Typeable' type and emits it as an event (see "Rasa.Internal.Events").
+--
+-- When you call 'asyncEventProvider' you pass it a function which accepts a @dispatch@ function as an argument
+-- and then calls it with various events within the resulting 'IO'.
+--
+-- Note that asyncEventProvider calls forkIO internally, so there's no need to do that yourself.
+--
+-- Here's an example which fires a @Timer@ event every second.
+--
+-- > {-# language RankNTypes #-}
+-- > data Timer = Timer
+-- > myTimer :: dispatchEvent -> IO ()
+-- > myTimer dispatch = forever $ dispatch Timer >> threadDelay 1000000
+-- >
+-- > myAction :: Action ()
+-- > myAction = onInit $ asyncEventProvider myTimer
+asyncEventProvider :: (Dispatcher -> IO ()) -> Action ()
+asyncEventProvider asyncEventProv =
+  asyncActionProvider $ eventsToActions asyncEventProv
+    where
+      eventsToActions :: (Dispatcher -> IO ()) -> (Action () -> IO ()) -> IO ()
+      eventsToActions aEventProv dispatcher = aEventProv (dispatcher . dispatchEvent)
+
+
+-- | This function takes an IO which results in some Event, it runs the IO
+-- asynchronously and dispatches the event
+dispatchEventAsync :: Typeable event => IO event -> Action ()
+dispatchEventAsync ioEvent = dispatchActionAsync $ dispatchEvent <$> ioEvent
+
+dispatchEvent :: forall result eventType. (Monoid result, Typeable eventType, Typeable result) => (eventType -> Action result)
+dispatchEvent evt = do
+      GlobalListeners _ listeners <- getExt
+      results <- traverse ($ evt) (matchingListeners listeners)
+      return $ mconcat results
+
+addListener :: forall result eventType. (Typeable eventType) => (eventType -> Action result) -> Action ListenerId
+addListener lFunc = do
+  GlobalListeners nextListenerId listeners  <- getExt
+  let (listener, listenerId, eventType) = mkListener nextListenerId lFunc
+      newListeners = M.insertWith mappend eventType [listener] listeners
+  setExt $ GlobalListeners (nextListenerId + 1) newListeners
+  return listenerId
+    where
+      mkListener :: forall event r. Typeable event => Int -> (event -> Action r) -> (Listener, ListenerId, TypeRep)
+      mkListener n listenerFunc =
+        let list = Listener listId (void . listenerFunc)
+            listId = ListenerId n (typeRep (Proxy :: Proxy event))
+            prox = typeRep (Proxy :: Proxy event)
+          in (list, listId, prox)
+

--- a/rasa/src/Rasa/Internal/Listeners.hs
+++ b/rasa/src/Rasa/Internal/Listeners.hs
@@ -17,10 +17,14 @@ module Rasa.Internal.Listeners
   , removeListener
   , onBufAdded
   , onBufTextChanged
+
+  , onKeypress
+  , dispatchKeypress
   ) where
 
 
 import Rasa.Internal.Action
+import qualified Rasa.Internal.Actions as A
 import Rasa.Internal.Events
 import Rasa.Internal.Editor
 import Rasa.Internal.Range
@@ -28,6 +32,12 @@ import Rasa.Internal.Range
 import Control.Monad
 import Data.Dynamic
 import qualified Yi.Rope as Y
+
+onKeypress :: (Keypress -> Action ()) -> Action A.ListenerId
+onKeypress = A.mkRegistrar
+
+dispatchKeypress :: Keypress -> Action ()
+dispatchKeypress = A.mkDispatcher
 
 -- | This registers an event listener, as long as the listener is well-typed similar to this:
 --

--- a/rasa/src/Rasa/Internal/Listeners.hs
+++ b/rasa/src/Rasa/Internal/Listeners.hs
@@ -8,10 +8,12 @@
 module Rasa.Internal.Listeners
   ( dispatchEvent
   , addListener
+  , addListener_
   , removeListener
 
   , dispatchBufEvent
   , addBufListener
+  , addBufListener_
   , removeBufListener
 
   , Dispatcher
@@ -294,6 +296,9 @@ dispatchEvent = dispatchEventG
 addListener :: forall result eventType. (Typeable eventType) => (eventType -> Action result) -> Action ListenerId
 addListener = addListenerG
 
+addListener_ :: forall result eventType. (Typeable eventType) => (eventType -> Action result) -> Action ()
+addListener_ = void <$> addListener
+
 -- | Removes the listener represented by the given ListenerId.
 removeListener :: ListenerId -> Action ()
 removeListener = removeListenerG
@@ -307,6 +312,9 @@ dispatchBufEvent = dispatchEventG
 -- See 'addListener'
 addBufListener :: forall result eventType. (Typeable eventType) => (eventType -> BufAction result) -> BufAction ListenerId
 addBufListener = addListenerG
+
+addBufListener_ :: forall result eventType. (Typeable eventType) => (eventType -> BufAction result) -> BufAction ()
+addBufListener_ = void <$> addBufListener
 
 -- | Removes a listener from the BufAction's buffer.
 -- See 'removeListener'

--- a/rasa/src/Rasa/Testing.hs
+++ b/rasa/src/Rasa/Testing.hs
@@ -2,8 +2,7 @@ module Rasa.Testing (
   testBufAction
   ) where
 
-
-import Rasa.Internal.Action
+import Rasa.Internal.Interpreters
 import Rasa.Internal.Actions
 import Rasa.Internal.BufAction
 


### PR DESCRIPTION
I recently realized that with a bit of cleverness we could implement the event system using only the extension system. Pros/Cons listed below. 

This would nullify the need for https://github.com/ChrisPenner/rasa/pull/41

## Benefits:
- Allows me to delete a bunch of code from core
-  Improves type safety of the event system by requiring explicit types in event dispatchers and listeners (it was pretty easy to mess up with all the polymorphic types before).
- Allows buffer-specific event-listeners and event dispatch which is pretty cool.
- Makes 'returned' values from event dispatching easy and type-safe (I don't have example yet though sorry 😋 )

## Downsides:
- Extensions must now create their own `dispatch` and `register` functions to avoid `ambiguous type` errors; this is a feature in disguise because now the use of these functions will throw errors if used with the wrong types (whereas the old dispatchEvent didn't). I've provided `dispatchEvent` and `addListener` which essentially automate the process; you just need to specify your type signature to use these.
- Since this is now implemented as part of the extension system it prevents us from tracking every dispatched event through interpreting the `DispatchEvent` free monad; this may reduce flexibility when we start looking at undo trees etc. in the future. I think we could build it back into `dispatchEvent` in the future if we like.
- 

Here's an example of how an extension (a simple clipboard ext) would set up its listeners/dispatchers by using more concrete types:

```haskell
data Copied = Copied Y.YiString

onCopy :: (Copied -> Action ()) -> Action ()
onCopy = dispatchEvent

dispatchCopy :: Copied -> Action ()
dispatchCopy = addListener
```