### PR TITLE
Generalise types of logInfo and logError

### DIFF
--- a/rasa-ext-logger/src/Rasa/Ext/Logger.hs
+++ b/rasa-ext-logger/src/Rasa/Ext/Logger.hs
@@ -7,6 +7,7 @@ module Rasa.Ext.Logger
 import Rasa.Ext
 
 import Control.Monad.State
+import Control.Monad.IO.Class (MonadIO)
 
 logger :: App ()
 logger = do
@@ -15,8 +16,8 @@ logger = do
     -- ed <- getEditor
     -- liftIO $ appendFile "logs.log" (show ed)
 
-logInfo :: String -> App ()
+logInfo :: MonadIO m => String -> m ()
 logInfo msg = liftIO $ appendFile "info.log" ("INFO: " ++ msg ++ "\n")
 
-logError :: String -> App ()
+logError :: MonadIO m => String -> m ()
 logError msg = liftIO $ appendFile "error.log" ("ERROR: " ++ msg ++ "\n")


### PR DESCRIPTION
This allows to use `logInfo` and `logError` in the `BufAction` monad which is quite useful to troubleshoot extensions.

PS: It would be nice to revive `logger` too, but I'm not sure which way to go yet. Would a bunch of `Show` instances on `AppState` do?