### PR TITLE
Demo syntax and syntax-markdown extensions #65

### DIFF
--- a/rasa-example-config/app/Main.hs
+++ b/rasa-example-config/app/Main.hs
@@ -9,6 +9,8 @@ import Rasa.Ext.Files
 import Rasa.Ext.Logger
 import Rasa.Ext.Cursors
 import Rasa.Ext.Slate
+import Rasa.Ext.Syntax
+import Rasa.Ext.Syntax.Markdown
 
 -- import Control.Monad
 -- import Control.Monad.Trans
@@ -26,4 +28,5 @@ main = rasa $ do
   cursors
   logger
   slate
+  syntax [markdown [Extension ".md"]]
   afterInit $ addBuffer "This is a buffer to get you started!\nYou can also pass command line args to rasa"

--- a/rasa-example-config/rasa-example-config.cabal
+++ b/rasa-example-config/rasa-example-config.cabal
@@ -24,6 +24,8 @@ executable rasa
                      , rasa-ext-logger
                      , rasa-ext-files
                      , rasa-ext-slate
+                     , rasa-ext-syntax
+                     , rasa-ext-syntax-markdown
                      , lens
                      , data-default
                      , yi-rope

--- a/rasa-ext-files/rasa-ext-files.cabal
+++ b/rasa-ext-files/rasa-ext-files.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:
                        Rasa.Ext.Files
+                       Rasa.Ext.Files.Internal.Events
 
   build-depends:       base >= 4.8 && < 5
                      , rasa

--- a/rasa-ext-files/rasa-ext-files.cabal
+++ b/rasa-ext-files/rasa-ext-files.cabal
@@ -28,6 +28,9 @@ library
                      , text
                      , mtl
                      , yi-rope
+                     , filepath
+                     , directory
+
   default-language:    Haskell2010
 
   default-extensions:

--- a/rasa-ext-files/src/Rasa/Ext/Files.hs
+++ b/rasa-ext-files/src/Rasa/Ext/Files.hs
@@ -5,6 +5,10 @@
 module Rasa.Ext.Files
   ( files
   , save
+  -- Events
+  , onFileLoaded
+  , dispatchFileLoaded
+  , FileLoaded(..), Extension(..)
   ) where
 
 import qualified Data.Text.IO as TIO
@@ -101,9 +105,16 @@ setFilename fname = setBufExt $ FileInfo (Just fname)
 
 -- | Add a buffer for a file
 addFile :: String -> Y.YiString -> App ()
-addFile fname txt = do
-  newBuf <- addBuffer txt
-  bufDo_ newBuf (setFilename fname)
+addFile fname txt =
+  do
+    newBuf <- addBuffer txt
+    dispatchFileLoaded $ extOf fname newBuf
+    bufDo_ newBuf (setFilename fname)
+  where
+    extOf f buf = FileLoaded (safeExt f) buf
+    safeExt f = case FilePath.takeExtensions f of
+      ext -> Extension $ ext
+      "" -> UnknownExtension
 
 -- | Load files from command line
 loadFiles :: App ()

--- a/rasa-ext-files/src/Rasa/Ext/Files/Internal/Events.hs
+++ b/rasa-ext-files/src/Rasa/Ext/Files/Internal/Events.hs
@@ -1,0 +1,18 @@
+module Rasa.Ext.Files.Internal.Events where
+
+import Rasa.Ext
+
+import Control.Monad
+
+data Extension = Extension String | UnknownExtension deriving (Eq)
+
+data FileLoaded
+  = FileLoaded Extension BufRef
+
+-- | Trigger an 'App' on a 'Keypress'
+onFileLoaded :: (FileLoaded -> App result) -> App ListenerId
+onFileLoaded actionF = addListener (void <$> actionF)
+
+-- | Dispatch a 'Keypress' event.
+dispatchFileLoaded :: FileLoaded -> App ()
+dispatchFileLoaded = dispatchEvent

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,6 +24,10 @@ packages:
 extra-deps:
 - eve-0.1.7
 - vty-5.25
+- git: git@github.com:iilab/rasa-ext-syntax.git
+  commit: 20bbd32
+- git: git@github.com:iilab/rasa-ext-syntax-markdown.git
+  commit: 9e326a8
 - recursion-schemes-5.0.2
 
 # Uncomment the following if you'd like to use a locally installed version


### PR DESCRIPTION
And building on #65 here's a demo of the syntax modules (for now pinned to github commits). It would be great if you could take a look at
 - https://github.com/iilab/rasa-ext-syntax/commit/20bbd32d703537d86d01f1291bef1a722523e7a2
 - https://github.com/iilab/rasa-ext-syntax-markdown/commit/9e326a8ffef5f18c7cf00f1df47d442b8857306d

before I make the jump to submit my first packages on hackage?

The idea is that a syntax extension implements
```haskell
type Lexer a = Y.YiString -> Tokens a
type Styler a = TokenRange a -> BufAction (Span CrdRange Style)
type Mapper = [Extension]
data Syntax a = Syntax String Mapper (Lexer a) (Styler a)
```

for instance:
```haskell
markdown :: Mapper -> Syntax MarkdownToken
markdown mapper = Syntax "Markdown" mapper lexer styler
```

Which then allows to add extensions like so:
```haskell
main :: IO ()
main = rasa $ do
  ...
  syntax [markdown [Extension ".md"]]
```
