### PR TITLE
[WIP] Combine spans

### DIFF
--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors/Internal/Actions.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors/Internal/Actions.hs
@@ -28,9 +28,9 @@ moveSameLineRangesBy (Range _ (Coord endRow endCol)) amt = do
 
 -- | Delete the text of all ranges in a buffer
 delete :: BufAction ()
-delete = rangeDo_ $ \r -> do
-  deleteRange r
-  moveSameLineRangesBy r (negate $ sizeOfR r)
+delete = rangeDo_ $ \(Range s e) -> do
+  deleteRange (Range s (e+1))
+  moveSameLineRangesBy (Range s (e+1)) (negate $ sizeOfR (Range s (e+1)))
 
 -- | Insert text at the beginning of all ranges in the buffer.
 insertText :: Y.YiString -> BufAction ()

--- a/rasa-ext-cursors/src/Rasa/Ext/Cursors/Internal/Base.hs
+++ b/rasa-ext-cursors/src/Rasa/Ext/Cursors/Internal/Base.hs
@@ -27,20 +27,20 @@ data Cursors =
   deriving (Typeable, Show)
 
 instance Default Cursors where
-  def = Cursors [Range (Coord 0 0) (Coord 0 1)]
+  def = Cursors [Range (Coord 0 0) (Coord 0 0)]
 
 -- | Adjusts input ranges to contain at least one character.
-ensureSize :: CrdRange -> CrdRange
-ensureSize r@(Range start end)
-  | start == end =
-    if start^.coordCol == 0 then r & rEnd %~ moveCursorByN 1
-                          else r & rStart %~ moveCursorByN (-1)
-  | otherwise = r
+-- ensureSize :: CrdRange -> CrdRange
+-- ensureSize r@(Range start end)
+--   | start == end =
+--     if start^.coordCol == 0 then r & rEnd %~ moveCursorByN 1
+--                           else r & rStart %~ moveCursorByN (-1)
+--   | otherwise = r
 
 -- | Sorts Ranges, removes duplicates, ensures they contain at least one character
 -- and restricts them to fit within the given text.
 cleanRanges :: Y.YiString -> [CrdRange] -> [CrdRange]
-cleanRanges txt = fmap (ensureSize . clampRange txt) . reverse . nub . sort
+cleanRanges txt = fmap (clampRange txt) . reverse . nub . sort
 
 -- | Get the list of ranges
 getRanges :: BufAction [CrdRange]

--- a/rasa-ext-slate/rasa-ext-slate.cabal
+++ b/rasa-ext-slate/rasa-ext-slate.cabal
@@ -31,7 +31,8 @@ library
                      , yi-rope
                      , lens
                      , vty >= 5.25
-                     , rasa-ext-logger
+                     , data-default
+
   default-language:    Haskell2010
 
   ghc-options:         -Wall

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
@@ -72,7 +72,7 @@ applyAttrs (RenderInfo txt styles) =
       -- Add def style as base style covering the whole text
       base = [Span (Range (toCoord txt 0) (toCoord txt (Y.length txt))) def]
       atts = second convertStyle <$> ( base <> styles )
-      combined = trace "combined: " $ combineSpans txt (fmap AttrMonoid <$> atts)
+      combined = combineSpans txt (fmap AttrMonoid <$> atts)
       mergedSpans = second getAttr <$> combined
       spans' = over (mapped . _1) (view (asCoord txt)) mergedSpans
       -- Newlines aren't rendered; so we replace them with spaces so they're selectable

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
@@ -7,6 +7,8 @@ import qualified Graphics.Vty as V
 import Data.Bifunctor
 import Data.Text (Text, pack)
 
+import Control.Lens
+
 -- | Convert style from "Rasa.Ext.Style" into 'V.Attr's
 convertStyle :: Style -> V.Attr
 convertStyle (Style (fg', bg', flair')) = V.Attr

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
@@ -46,9 +46,8 @@ reset :: V.Image
 reset = V.text' V.defAttr ""
 
 -- | A newtype to define a (not necessarily law abiding) Monoid for 'V.Attr' which acts as we like.
-newtype AttrMonoid = AttrMonoid {
-  getAttr :: V.Attr
-}
+newtype AttrMonoid = AttrMonoid { getAttr :: V.Attr }
+  deriving (Show)
 
 instance Semigroup AttrMonoid where
   AttrMonoid v <> AttrMonoid v' = AttrMonoid $ v <> v'

--- a/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
+++ b/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs
@@ -10,10 +10,10 @@ import Data.Text (Text, pack)
 -- | Convert style from "Rasa.Ext.Style" into 'V.Attr's
 convertStyle :: Style -> V.Attr
 convertStyle (Style (fg', bg', flair')) = V.Attr
-                                        (maybe V.KeepCurrent convertFlair flair')
-                                        (maybe V.KeepCurrent convertColor fg')
-                                        (maybe V.KeepCurrent convertColor bg')
-                                        (maybe V.KeepCurrent convertUrl (Just ""))
+                                        (maybe V.Default convertFlair flair')
+                                        (maybe V.Default convertColor fg')
+                                        (maybe V.Default convertColor bg')
+                                        (maybe V.Default convertUrl (Just ""))
 
 -- | Convert flair from "Rasa.Ext.Style" into 'V.Style's
 convertFlair :: Flair -> V.MaybeDefault V.Style

--- a/rasa-ext-vim/src/Rasa/Ext/Vim.hs
+++ b/rasa-ext-vim/src/Rasa/Ext/Vim.hs
@@ -131,7 +131,7 @@ normal [KDown []] = runApp focusViewBelow
 
 normal [Keypress 'G' []] = do
   txt <- getText
-  setRanges [Range ((Offset $ Y.length txt - 1)^.asCoord txt) ((Offset $ Y.length txt)^.asCoord txt)]
+  setRanges [Range ((Y.length txt - 1)^.asCoord txt) ((Y.length txt)^.asCoord txt)]
 
 normal [Keypress 'o' []] = endOfLine >> insertText "\n" >> moveRangesByC (Coord 1 0) >> setMode Insert
 normal [Keypress 'O' []] = startOfLine >> insertText "\n" >> setMode Insert

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -77,6 +77,8 @@ library
                      , transformers
                      , yi-rope
                      , hspec
+                     , IntervalMap
+
 
   default-language:    Haskell2010
 
@@ -93,6 +95,8 @@ test-suite rasa-test
                      , text
                      , quickcheck-instances
                      , QuickCheck
+                     , containers
+                     , IntervalMap
 
   other-modules:       ArbitraryInstances
                      , RasaSpec

--- a/rasa/rasa.cabal
+++ b/rasa/rasa.cabal
@@ -96,6 +96,7 @@ test-suite rasa-test
                      , quickcheck-instances
                      , QuickCheck
                      , containers
+                     , data-default
                      , IntervalMap
 
   other-modules:       ArbitraryInstances

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -104,9 +104,10 @@ module Rasa.Ext
    -- * Ranges
   , Range(..)
   , CrdRange
+  , PosRange
   , Coord
   , Coord'(..)
-  , Offset(..)
+  , Pos(..)
   , Span(..)
   , overRow
   , overCol

--- a/rasa/src/Rasa/Ext.hs
+++ b/rasa/src/Rasa/Ext.hs
@@ -116,6 +116,8 @@ module Rasa.Ext
   , overBoth
   , combineSpans
   , asCoord
+  , toPos
+  , toCoord
   , clampCoord
   , clampRange
   , rStart

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -74,19 +74,28 @@ instance (Ord a, Ord b) => Ord (Range a b) where
     | end == end' = start <= start'
     | otherwise = end <= end'
 
--- | (Coord Row Column) represents a char in a block of text. (zero indexed)
 -- | A type alias to 'Range'' which specializes the types to 'Pos's.
 type PosRange = (Pos, Pos)
+
+-- | A span which maps a piece of Monoidal data over a range.
+data Span a b =
+  Span a b
+  deriving (Show, Eq, Functor)
+
+instance Bifunctor Span where
+  bimap f g (Span a b) = Span (f a) (g b)
+
+-- | (Coord Row Column) represents a coordinate on screen. (zero indexed)
 -- e.g. Coord 0 0 is the first character in the text,
 -- Coord 2 1 is the second character of the third row
-data Coord' a b = Coord 
+data Coord' a b = Coord
   { _coordRow::a
   , _coordCol::b
   } deriving (Eq)
 makeLenses ''Coord'
 
 instance (Show a, Show b) => Show (Coord' a b) where
-  show (Coord a b) = "(Coord (row " ++ show a ++ ") (col " ++ show b ++ "))"
+  show (Coord a b) = "(Coord " ++ show a ++ " " ++ show b ++ ")"
 
 -- | A type alias to 'Coord'' which specializes the types to integers.
 type Coord = Coord' Int Int
@@ -120,13 +129,7 @@ instance (Ord a, Ord b) => Ord (Coord' a b) where
     | otherwise = b <= b'
 
 
--- | A span which maps a piece of Monoidal data over a range.
-data Span a b =
-  Span a b
-  deriving (Show, Eq, Functor)
 
-instance Bifunctor Span where
-  bimap f g (Span a b) = Span (f a) (g b)
 
 -- | Moves a 'Range' by a given 'Coord'
 -- It may be unintuitive, but for (Coord row col) a given range will be moved down by row and to the right by col.

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -47,7 +47,10 @@ import Data.Bifoldable
 
 import qualified Yi.Rope as Y
 
--- | This represents a range between two coordinates ('Coord')
+-- | This represents a position in the text
+type Pos = Int
+
+-- | This represents a range between two positions ('Pos')
 data Range a b = Range
   { _rStart :: a
   , _rEnd :: b
@@ -72,6 +75,8 @@ instance (Ord a, Ord b) => Ord (Range a b) where
     | otherwise = end <= end'
 
 -- | (Coord Row Column) represents a char in a block of text. (zero indexed)
+-- | A type alias to 'Range'' which specializes the types to 'Pos's.
+type PosRange = (Pos, Pos)
 -- e.g. Coord 0 0 is the first character in the text,
 -- Coord 2 1 is the second character of the third row
 data Coord' a b = Coord 
@@ -114,10 +119,6 @@ instance (Ord a, Ord b) => Ord (Coord' a b) where
     | a > a' = False
     | otherwise = b <= b'
 
--- | An 'Offset' represents an exact position in a file as a number of characters from the start.
-newtype Offset =
-  Offset Int
-  deriving (Show, Eq)
 
 -- | A span which maps a piece of Monoidal data over a range.
 data Span a b =

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -17,6 +17,8 @@ module Rasa.Internal.Range
   , coordCol
   , Pos
   , asCoord
+  , toPos
+  , toCoord
   , clampCoord
   , clampRange
   , Range(..)

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -245,6 +245,12 @@ instance Ord e => Interval (e, e) e where
     upperBound (_,b) = b
     rightClosed _ = False
 
+-- Spans seem like they're more than a semigroup as it should be possible
+-- to remove Spans from Spans. Like a Set, but slightly more because of the
+-- intervals, which should allow to remove " a " from "aaa" to give "a a".
+-- Possibly we want to allow to remove "aaa" from "a" as well to give "   ".
+-- A bit like if there was a set for each given Coord.
+
 type Spans a = IntervalMap PosRange a
 
 -- | Combines a list of spans containing some monoidal data into a list of

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -48,6 +48,7 @@ import Rasa.Internal.Text
 import Control.Lens
 
 import Data.Monoid
+import Data.Default
 import Data.List
 import Data.Bifunctor
 import Data.Biapplicative

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -179,8 +179,9 @@ clampCoord :: Y.YiString -> Coord -> Coord
 clampCoord txt (Coord row col) =
   Coord (clamp 0 maxRow row) (clamp 0 maxColumn col)
   where
-    maxRow = Y.countNewLines txt
-    selectedRow = fst . Y.splitAtLine 1 . snd . Y.splitAtLine row $ txt
+    l = Y.lines txt
+    maxRow = length l
+    selectedRow = maybe Y.empty id (l ^? element row)
     maxColumn = Y.length selectedRow
 
 -- | This will restrict a given 'Range' to a valid one which lies within the given text.

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -255,19 +255,13 @@ type Spans a = IntervalMap PosRange a
 
 -- | Combines a list of spans containing some monoidal data into a list of
 -- | positions with the data that applies from each Pos forwards.
-combineSpans :: (Monoid a) => Y.YiString -> [Span CrdRange a] -> [(Pos,a)]
-combineSpans txt spans = concat [ steps spans' , [final spans'] ]
+combineSpans :: (Monoid a, Default a) => Y.YiString -> [Span CrdRange a] -> [(Pos,a)]
+combineSpans txt spans = concat [ steps spans' ]
   where
     spans' = fromSpanList (map (posSpans txt) spans)
 
 posSpans :: Y.YiString -> Span CrdRange a -> Span PosRange a
 posSpans txt (Span (Range s e) a) = Span (toPos txt s, (toPos txt e) + 1) a
-
-final :: Monoid a => Spans a -> (Pos, a)
-final s
-  | null s = (0, mempty)
-  | otherwise = case IM.findMax s of
-    (i,_) -> (upperBound i,mempty)
 
 steps :: Spans a -> [(Pos, a)]
 steps s = flip map (IM.toList s) $ \((s,_),a) -> (s,a)

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -237,10 +237,10 @@ afterC c@(Coord row col) = lens getter setter
 -- | A lens over text which is encompassed by a 'Range'
 range :: CrdRange -> Lens' Y.YiString Y.YiString
 range (Range start end) = lens getter setter
-  where getter = view (beforeC (end + 1) . afterC start)
+  where getter = view (beforeC end . afterC start)
         setter old new = result
           where
-            setBefore = old & beforeC (end + 1) .~ new
+            setBefore = old & beforeC end .~ new
             result = old & afterC start .~ setBefore
 
 instance Ord e => Interval (e, e) e where

--- a/rasa/src/Rasa/Internal/Range.hs
+++ b/rasa/src/Rasa/Internal/Range.hs
@@ -257,8 +257,8 @@ afterC c@(Coord row col) = lens getter setter
 -- | A lens over text which is encompassed by a 'Range'
 range :: CrdRange -> Lens' Y.YiString Y.YiString
 range (Range start end) = lens getter setter
-  where getter = view (beforeC end . afterC start)
+  where getter = view (beforeC (end + 1) . afterC start)
         setter old new = result
           where
-            setBefore = old & beforeC end .~ new
+            setBefore = old & beforeC (end + 1) .~ new
             result = old & afterC start .~ setBefore

--- a/rasa/test/Rasa/Internal/RangeSpec.hs
+++ b/rasa/test/Rasa/Internal/RangeSpec.hs
@@ -1,3 +1,14 @@
+{-# LANGUAGE
+  Rank2Types
+  , OverloadedStrings
+  , DeriveFunctor
+  , ScopedTypeVariables
+  , TemplateHaskell
+  , FlexibleInstances
+  , MultiParamTypeClasses
+  , ConstraintKinds
+  , FlexibleContexts
+#-}
 module Rasa.Internal.RangeSpec where
 
 import Test.Hspec
@@ -7,13 +18,192 @@ import ArbitraryInstances ()
 
 import Rasa.Internal.Range
 
+import Control.Monad.IO.Class (liftIO)
+import Data.Text (pack, Text())
+import Data.Text.IO as TIO
+
+import Data.List
+import Data.Tree
+
+import Control.Lens
+
+import Data.IntervalMap.Generic.Interval (Interval(..), lowerBound, upperBound, rightClosed, overlaps, isEmpty)
+import Data.IntervalMap.Generic.Strict (IntervalMap)
+import qualified Data.IntervalMap as IM
+
 spec :: Spec
 spec = do
-  describe "overRow" $
-    prop "overRow f ~= Coord (f a) b" $ \crd@(Coord r c) -> Coord (r+1) c `shouldBe` overRow (+1) crd
+  -- describe "overRow" $
+  --   prop "overRow f ~= Coord (f a) b" $ \crd@(Coord r c) -> Coord (r+1) c `shouldBe` overRow (+1) crd
+  --
+  -- describe "overCol" $
+  --   prop "overCol f ~= Coord a (f b)" $ \crd@(Coord r c) -> Coord r (c+1) `shouldBe` overCol (+1) crd
+  --
+  -- describe "overBoth" $
+  --   prop "overBoth f ~= Coord (f a) (f b)" $ \crd@(Coord r c) -> Coord (r+1) (c+1) `shouldBe` overBoth (+ (1 :: Int)) crd
 
-  describe "overCol" $
-    prop "overCol f ~= Coord a (f b)" $ \crd@(Coord r c) -> Coord r (c+1) `shouldBe` overCol (+1) crd
+  describe "combineSpans" $ do
+    -- it "noop" $ do
+    --   noop `shouldReturn` ()
 
-  describe "overBoth" $
-    prop "overBoth f ~= Coord (f a) (f b)" $ \crd@(Coord r c) -> Coord (r+1) (c+1) `shouldBe` overBoth (+ (1 :: Int)) crd
+    it "should deal with empty spans" $ do
+      combineSpans "     " (
+         [ ] :: [Span CrdRange String]
+        )
+      `shouldBe`
+        [ (0, "") ]
+
+    it "should deal with the unit spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 0)) "a")
+        ]
+      `shouldBe`
+        [ (0, "a")
+        , (1, "") ]
+
+    -- A = aaa
+    -- B =  b
+    --     ---
+    --     aaa.
+    --      b
+
+    it "should combine spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 2)) "a")
+        , (Span (Range (Coord 0 1) (Coord 0 1)) "b")
+        ]
+      `shouldBe`
+        [ (0,"a")
+        , (1,"ab")
+        , (2,"a")
+        , (3,"")
+        ]
+
+    -- A = a
+    -- B =  b
+    --     --
+    --     ab.
+
+    it "should combine consecutive spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 0)) "a")
+        , (Span (Range (Coord 0 1) (Coord 0 1)) "b")
+        ]
+      `shouldBe`
+        [ (0,"a")
+        , (1,"b")
+        , (2,"")
+        ]
+
+    -- A = aaaa
+    -- B =   b
+    --     ----
+    --     a aa.
+    --       b
+
+    it "should combine long spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 3)) "a")
+        , (Span (Range (Coord 0 2) (Coord 0 2)) "b")
+        ]
+      `shouldBe`
+        [ (0,"a")
+        , (2,"ab")
+        , (3,"a")
+        , (4,"")
+        ]
+
+    -- A = a.aa
+    -- B =   b
+    --     ----
+    --     a.aa.
+    --       b
+
+    -- A = a..a
+    -- B =   b
+    --     ----
+    --     a.ba.
+
+    -- A = aa
+    -- B =  bbb
+    --     ----
+    --     aab .
+    --      b
+
+    -- A = aaa
+    -- B =  bbb
+    -- B =   c
+    --     ----
+    --     aabb.
+    --      bc
+
+    it "should ignore spans with 0 size ranges" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 1) (Coord 0 0)) "a")
+        , (Span (Range (Coord 0 1) (Coord 0 0)) "b")
+        ]
+      `shouldBe`
+        [ (0,"")
+        ]
+
+    it "should combine spans containing mempty" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 1)) "")
+        , (Span (Range (Coord 0 0) (Coord 0 1)) "")
+        ]
+      `shouldBe`
+        [ (0, ""),
+          (2, "")
+        ]
+
+    it "should combine a single span" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 1)) "a")
+        ]
+      `shouldBe`
+        [ (0,"a")
+        , (2,"")
+        ]
+
+    it "should combine full spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 1)) "a")
+        , (Span (Range (Coord 0 0) (Coord 0 1)) "b")
+        ]
+      `shouldBe`
+        [ (0,"ab")
+        , (2,"")
+        ]
+
+    it "should combine three full spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 1)) "a")
+        , (Span (Range (Coord 0 0) (Coord 0 1)) "b")
+        , (Span (Range (Coord 0 0) (Coord 0 1)) "c")
+        ]
+      `shouldBe`
+        [ (0,"abc")
+        , (2,"")
+        ]
+
+    it "should ignore empty spans" $ do
+      combineSpans "     "
+        [ (Span (Range (Coord 0 0) (Coord 0 1)) "a")
+        , (Span (Range (Coord 0 1) (Coord 0 0)) "b")
+        ]
+      `shouldBe`
+        [ (0,"a")
+        , (2,"")
+        ]
+
+    it "should combine multiline spans" $ do
+      combineSpans "     \n     "
+        [ (Span (Range (Coord 0 0) (Coord 1 2)) "a")
+        , (Span (Range (Coord 1 1) (Coord 1 1)) "b")
+        ]
+      `shouldBe`
+        [ (0,"a")
+         ,(7,"ab")
+         ,(8,"a")
+         ,(9,"")
+        ]


### PR DESCRIPTION
Hi @ChrisPenner

So here's the work in progress with combineSpans, dealing with part of the consequences of the fix. Here's a few things worth noting:
 - The Default instance for Cursors used an exclusive interval
 - The `range` lens ended up being off by one with the new combineSpans implementation
 - The above, and the fact that thinking of Ranges as mathematical intervals `[0,1[` really makes more sense to me, means that I'd prefer continuing by changing the interval to have an exclusive upper bound. I haven't done it yet, but I'd really like to convince you :)
 - As we already discussed a bit, I think that we should be able to make things more easy to reason about by separating the abstractions of ranges over text and screen coordinates more neatly. I think it's not an Iso by the way because of the clamping.

While tracing the render code I noticed that spans in one line are computed as deeply nested `HorizJoin`s because of the recursion in `attrLine`, that was probably not intentional?

with regards to combineSpans, I've used the IntervalMap package and the top level algorithm chops things in the following way:
  - split all values in the map with the upper and lower bounds of inserted value
  - split inserted value with all the intervals in the intersecting map
  - unionWith with `<>`

It really feels that the implementation could be improved massively. It's so far from being done in one pass but it feels like it should be possible. Also as we discussed, pushing the data inside the text data structure might be useful? I'm not so sure anymore, and intuitively still think, though don't understand nearly as much as I'd like to, that we're thinking of something that Kmett thought all the way through, including in how he packs his data in trees that somehow take advantage of the structure of the Dyck language which has a similar structure as our `Range` (and what he adds with relative deltas) and that this will somehow help when we'll want to do incremental parsing... But replacing `Yi.Rope` is way above my ability, but maybe not yours :)

Also I think there's still something unclear for me about dealing with defaults and current styles within the Style Monoid or AttrMonoid... I guess the abstractions should be `resetting` the styles to get the defaults, and a `transparent` style (or front, back colors and flairs) which keeps the current style (or front, back, flair), so it seems that we need a *neutral* element **and** and *absorbing* element? 

UPDATE: Looking at this again, and given [this comment](https://github.com/ChrisPenner/rasa/blob/7094ed101fc44931a734b5a3aa577a6b6e874be1/rasa/src/Rasa/Internal/Styles.hs#L52), I think the Monoid instance of Style is intended to be the neutral element and the Default instance to be the absorbing element. But with AttrMonoid, [the Monoid instance is absorbing](https://github.com/ChrisPenner/rasa/blob/7094ed101fc44931a734b5a3aa577a6b6e874be1/rasa-ext-slate/src/Rasa/Ext/Slate/Internal/Attributes.hs#L57-L59) this should probably be consistent...

UDPDATE2: In which case we might want to use [Zero](http://hackage.haskell.org/package/zero-0.1.4/docs/Data-Zero.html) instead of `Default`?

Finally, there are still some things that seem broken, like hitting `G` in insert mode seems to make the cursor range blow up.

Phew. That was a deep dive and much good learning :)

Jun